### PR TITLE
add RTLD_GLOBAL to dlopen for modules

### DIFF
--- a/src/pdsh/mod.c
+++ b/src/pdsh/mod.c
@@ -803,7 +803,13 @@ _mod_load_dynamic(const char *fq_path)
 
     mod = mod_create();
 
-    if (!(mod->handle = dlopen(fq_path, RTLD_NOW)))
+    /*  RTLD_GLOBAL is used here so that symbols in any libraries
+     *  linked to by the loaded module are global, such that any DSOs
+     *  dlopened in turn by those libraries can find symbols in
+     *  their parent library. This is specifically a problem with the
+     *  nodeupdown and slurm modules at this time.
+     */
+    if (!(mod->handle = dlopen(fq_path, RTLD_GLOBAL | RTLD_NOW)))
         goto fail;
 
     mod->filename = Strdup(fq_path);


### PR DESCRIPTION
Problem: Loading the slurm and nodeupdown modules wasn't working
with complaints about missing symbols from DSOs loaded by libslurm
and libnodeupdown. The assumption is that this is caused by symbols
in these libraries not having global scope since they were loaded
without RTLD_GLOBAL by pdsh dlopen(3).

This has been solved in the past by calling dlopen() with RTLD_GLOBAL
on these libraries in their respective modules instead of linking
to them directly. However, for now, it will be simpler to have
pdsh use RTLD_GLOBAL directly, since no issues are anticipated with
that approach.

If, in the future, the use of RTLD_GLOBAL causes issues, the alternate
fix can be used.

Fixes #98