### PR TITLE
implement -A optional flag to return all exit codes on stdout

### DIFF
--- a/doc/pdsh.1.in
+++ b/doc/pdsh.1.in
@@ -148,6 +148,9 @@ character.
 .I "-S"
 Return the largest of the remote command return values.
 .TP
+.I "-A"
+Return all individual exit codes
+.TP
 .I "-h"
 Output usage menu and quit. A list of available rcmd modules
 will also be printed at the end of the usage message.

--- a/src/common/pipecmd.c
+++ b/src/common/pipecmd.c
@@ -226,7 +226,11 @@ int pipecmd_wait (pipecmd_t p, int *pstatus)
         err ("%p: %S: %s pid %ld: waitpid: %m\n", p->target, 
                 xbasename (p->path), p->pid);
 
-    if (status != 0)
+    if (rc_all_display)
+        out ("%p: %S: %s exited with exit code %d\n",
+                p->target, xbasename (p->path), WEXITSTATUS (status));
+
+    else if (status != 0)
         err ("%p: %S: %s exited with exit code %d\n",
                 p->target, xbasename (p->path), WEXITSTATUS (status));
 

--- a/src/pdsh/opt.c
+++ b/src/pdsh/opt.c
@@ -66,7 +66,9 @@
 
 #define OPT_USAGE_DSH "\
 Usage: pdsh [-options] command ...\n\
--S                return largest of remote command return values\n"
+-S                return largest of remote command return values\n\
+-A                return all exit codes on stdout\n"
+
 
 /* -s option only useful on AIX */
 #if	HAVE_MAGIC_RSHELL_CLEANUP
@@ -113,9 +115,9 @@ Usage: rpdcp [-options] src [src2...] dir\n\
 /* undocumented "-K" option -  keep domain name in output */
 
 #if	HAVE_MAGIC_RSHELL_CLEANUP
-#define DSH_ARGS	"sS"
+#define DSH_ARGS	"sSA"
 #else
-#define DSH_ARGS    "S"
+#define DSH_ARGS    "SA"
 #endif
 #define PCP_ARGS	"pryzZe:"
 #define GEN_ARGS	"hLNKR:M:t:cqf:w:x:l:u:bI:dVT:Q"
@@ -419,6 +421,8 @@ void opt_default(opt_t * opt, char *argv0)
     opt->pcp_client = false;
     opt->pcp_client_host = NULL;
 
+    rc_all_display = 0;
+
     return;
 }
 
@@ -587,6 +591,9 @@ void opt_args(opt_t * opt, int argc, char *argv[])
 
         /*  Continue processing regular options...
          */
+        case 'A':
+            rc_all_display = 1;
+            break;
         case 'N':
             opt->labels = false;
             break;

--- a/src/pdsh/opt.h
+++ b/src/pdsh/opt.h
@@ -108,6 +108,10 @@ void opt_free(opt_t *);
  */
 pers_t pdsh_personality(void);
 
+/*
+ * Used to trigger the -A option in pipecmd.c, print every exit code on stdout
+ */
+int rc_all_display;
 
 /*
  *  Return a list of the original remote args


### PR DESCRIPTION
Hello @grondo, would it be ok to implement #58 

you mentioned in the past that -A may already be used, I can switch to any letter you want, just tell me which one you prefer ? -E maybe ?

thanks in advance.