### PR TITLE
travis-ci: fix failed builds and error messages from pipecmd

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,9 +38,9 @@ script:
         scripts/travis-ci-deps.sh;
         eval $(scripts/travis-ci-deps.sh --printenv);
     fi
-  - export CFLAGS="-Werror -Wno-error=deprecated-declarations"
   - ./bootstrap
   - ./configure --with-exec --with-ssh --with-mrsh --with-genders --with-dshgroups --with-netgroup --with-machines
+  - export CFLAGS="-Werror -Wno-error=deprecated-declarations"
   - make -j 2 check
 
 after_failure:

--- a/configure.ac
+++ b/configure.ac
@@ -77,6 +77,9 @@ AC_CHECK_LIB([socket], [socket], LIBS="-lsocket -lnsl $LIBS",, [-lsocket -lnsl])
 
 # Check for how to compile pthread programs:
 ACX_PTHREAD
+if test x"$acx_pthread_ok" = "xno"; then
+    AC_MSG_ERROR([Could not figure out how to compile with pthreads.])
+fi
 AC_DEFINE(WITH_PTHREADS, 1, [Define if you have pthreads])
 
 # PTHREAD_CFLAGS needs to be appended to both LDFLAGS and CPPFLAGS or some

--- a/src/common/pipecmd.c
+++ b/src/common/pipecmd.c
@@ -226,9 +226,17 @@ int pipecmd_wait (pipecmd_t p, int *pstatus)
         err ("%p: %S: %s pid %ld: waitpid: %m\n", p->target, 
                 xbasename (p->path), p->pid);
 
-    if (status != 0)
-        err ("%p: %S: %s exited with exit code %d\n",
-                p->target, xbasename (p->path), WEXITSTATUS (status));
+    if (status != 0) {
+        if (WIFEXITED (status))
+            err ("%p: %S: %s exited with exit code %d\n",
+                 p->target, xbasename (p->path), WEXITSTATUS (status));
+        else if (WIFSIGNALED (status))
+            err ("%p: %S: %s killed by signal %d\n",
+                 p->target, xbasename (p->path), WTERMSIG (status));
+        else
+            err ("%p: %S: %s exited with nonzero status 0x%04x\n",
+                 p->target, xbasename (p->path), status);
+    }
 
     if (pstatus)
         *pstatus = status;


### PR DESCRIPTION
Current travis builds of pdsh are failing because `CFLAGS=-Werror` was being set before `./configure` is run, and some configure checks, most notably the pthreads checks, are sensitive to `-Werror` and fail due to warnings. Move the `CFLAGS` setting to after `./configure` is run to resolve this issue. Also, pdsh `./configure` should fail if pthreads is not detected, so add a fatal error when pthreads is not detected, instead of delaying the error to link time.

I also tried to set up code coverage checks inside of travis-ci, however, this was for some reason causing intermittent failures of both the dshbak and pdcp tests. I think this is an artifact of the travis environment, but while trying to track it down I noticed that the error message generated in `pipecmd.c` when child processes exit with non-zero status was not handling the case of termination by a signal, so that is fixed here as well.

The issue with check-code-coverage is not resolved so that is saved for a future PR.
