### PR TITLE
fix output corruption with more than 8K bytes and no newline

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -22,7 +22,8 @@ check_SCRIPTS = \
     t2001-ssh.sh \
     t2002-mrsh.sh \
     t5000-dshbak.sh \
-    t6036-long-output-lines.sh
+    t6036-long-output-lines.sh \
+    t6114-no-newline-corruption.sh
 
 TESTS = \
     $(check_SCRIPTS)

--- a/tests/t6114-no-newline-corruption.sh
+++ b/tests/t6114-no-newline-corruption.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+test_description='chaos/pdsh#114: pdsh garbles long output with no newline
+
+Test that pdsh handles lots of data with no newline.'
+
+. ${srcdir:-.}/test-lib.sh
+
+
+perl -e 'print "a" x 1024' > 1K
+perl -e 'print "a" x 8192' > 8K
+perl -e 'print "a" x 8195' > 8K+
+perl -e 'print "a" x 10000' > 10K
+
+for i in 1K 8K 8K+ 10K; do
+test_expect_success "pdsh does not garble $i with no newline" "
+	pdsh -w foo -N -Rexec cat $i > output.${i} &&
+	test_cmp ${i} output.${i}
+"
+done
+test_done

--- a/tests/t6114-no-newline-corruption.sh
+++ b/tests/t6114-no-newline-corruption.sh
@@ -18,4 +18,12 @@ test_expect_success "pdsh does not garble $i with no newline" "
 	test_cmp ${i} output.${i}
 "
 done
+
+for i in 1K 8K 8K+ 10K; do
+test_expect_success "pdsh labels $i with no newline only once" '
+	pdsh -w foo -Rexec cat $i | sed "s/foo/\n&\n/g" > labels.${i} &&
+	test $(grep -c foo labels.${i}) -eq 1
+'
+done
+
 test_done


### PR DESCRIPTION
Fix the issue described in #114.

Turns out pdsh doesn't handle output without newlines too well, and output flush was reading from uninitialized memory for anything >= 8K bytes.

This PR also fixes arbitrary addition of newlines to output during the final flush.