### PR TITLE
pipecmd: fix result check error handling

### DIFF
--- a/src/common/pipecmd.c
+++ b/src/common/pipecmd.c
@@ -179,7 +179,7 @@ pipecmd_t pipecmd (const char *path, const char **args, const char *target,
     pipecmd_t p = pipe_info_create (path, target, user, rank);
     p->args = cmd_args_create (p, args);
 
-    if (!(p->fd = _pipecmd (p->path, p->args, &p->efd, &p->pid))) {
+    if ((p->fd = _pipecmd (p->path, p->args, &p->efd, &p->pid)) < 0) {
         err ("%p: exec cmd %s failed for host %S\n", path, target);
         pipecmd_destroy (p);
         return (NULL);


### PR DESCRIPTION
_pipecmd returns -1 on error, not 0 (since it's returning an fd). It may
in fact return 0 on success if stdin is closed, leading to a segfault.

This issue was discovered when running pdsh from a slurm suspend/resume program, where stdin is (inexplicably) closed.  However, it can be reproduced quite easily using `pdsh ... <&-`.

Presumably there's also a failure mode here where `_pipecmd` actually fails but this is not caught.