### PR TITLE
slurm: add -C to restrict hostlist to nodes with specified features

### DIFF
--- a/doc/pdsh.1.in
+++ b/doc/pdsh.1.in
@@ -303,6 +303,12 @@ argument "all" can be used to target all nodes running SLURM jobs, e.g.
 Target list of nodes containing in the SLURM partition \fIpartition\fR.
 This option may be used multiple times to target multiple SLURM partitions
 and/or partitions may be given in a comma-delimited list.
+.TP
+.I "-C feature[,feature,...]"
+Restrict selected nodes to those SLURM nodes that have one of the specified
+\fIfeature\fRs active.  This option should be used in combination with other
+node selectors, and filters the resulting list.  Any nodes that do not have
+one of the specified features (or is not a SLURM node) will be excluded.
 
 .SH "torque module options"
 The \fBtorque\fI module allows \fBpdsh\fR to target nodes based on

--- a/tests/t1003-slurm.sh
+++ b/tests/t1003-slurm.sh
@@ -133,6 +133,13 @@ test_expect_success 'slurm -P works with -w' '
 	fi
 '
 
+test_expect_success 'slurm -C filters out nodes' '
+	part=$(sinfo -ho %P | head -1)
+	if pdsh -P $part -C featurethathopefullydoesntexist -q ; then
+		say_color error "Error: pdsh -P $part -C featurethathopefullydoesntexist resulted in hosts"
+	fi
+'
+
 #
 #  Clean up:
 #


### PR DESCRIPTION
Like `srun -C`, this takes the produced hostlist and filters it to only SLURM nodes that have one of the specified features.  This is useful for us in combination with `-P`, but certainly open to other ideas.  One could imagine other slurm node filters as well, of course.  Does not accept the full slurm constraint syntax of `A&B|C` stuff, just a comma list that's essentially OR-d.