### PR TITLE
Remove README.QsNet from the RPM SPEC file's doc list

### DIFF
--- a/pdsh.spec
+++ b/pdsh.spec
@@ -280,7 +280,7 @@ rm -rf "$RPM_BUILD_ROOT"
 %files
 %defattr(-,root,root)
 %doc COPYING README NEWS DISCLAIMER.LLNS DISCLAIMER.UC
-%doc README.KRB4 README.modules README.QsNet
+%doc README.KRB4 README.modules
 %{_bindir}/pdsh
 %{_bindir}/pdcp
 %{_bindir}/rpdcp


### PR DESCRIPTION
This file doesn't exist and causes rpmbuild to fail when the file can't be
found

I ran into this bug on the tagged 2.34 release