### PR TITLE
build: Use LDADD instead of LDFLAGS for libcommon.la.

### DIFF
--- a/src/pdsh/Makefile.am
+++ b/src/pdsh/Makefile.am
@@ -16,9 +16,9 @@ else
 MODULE_FLAGS =             -export-dynamic $(AIX_PDSH_LDFLAGS) -ldl
 endif
 
-pdsh_LDADD =               $(READLINE_LIBS)
-pdsh_LDFLAGS =             $(MODULE_LIBS) $(MODULE_FLAGS) \
+pdsh_LDADD =               $(READLINE_LIBS) \
                            $(top_builddir)/src/common/libcommon.la
+pdsh_LDFLAGS =             $(MODULE_LIBS) $(MODULE_FLAGS)
 
 pdsh_inst_LDADD =          $(pdsh_LDADD)
 pdsh_inst_LDFLAGS =        $(pdsh_LDFLAGS)


### PR DESCRIPTION
When building pdsh with slibtool (https://dev.midipix.org/cross/slibtool) it fails with many undefined references.

This is because of this command-line:
```
clang ../../src/common/.libs/libcommon.a main.o dsh.o mod.o rcmd.o opt.o 
privsep.o pcp_server.o pcp_client.o testcase.o wcoll.o cbuf.o config.o -O3 
-Wall -fno-strict-aliasing -ldl -s -pthread -o .libs/pdsh.inst -Wl,--export-dynamic
```
While with GNU libtool it works.
```
clang -O3 -Wall -fno-strict-aliasing -s -pthread -o pdsh.inst main.o dsh.o 
mod.o rcmd.o opt.o privsep.o pcp_server.o pcp_client.o testcase.o wcoll.o 
cbuf.o config.o -Wl,--export-dynamic  -ldl ../../src/common/.libs/libcommon.a -pthread
```
This is because by chance GNU libtool orders `../../src/common/.libs/libcommon.a` at the end while slibtool places it at the beginning. This happens because `src/pdsh/Makefile.am` uses `LDFLAGS` instead of `LDADD` for `../../src/common/.libs/libcommon.a`, when using `LDADD` instead it is explicitly placed at the end and the build succeeds.

Here is a build log for reference: [pdsh.slibtool.log](https://github.com/chaos/pdsh/files/6152058/pdsh.slibtool.log)
GNU libtool log: [pdsh.libtool.log](https://github.com/chaos/pdsh/files/6152060/pdsh.libtool.log)

Also see this downstream issue: https://bugs.gentoo.org/775593
