### PR TITLE
dshbak: fix handling of empty input lines

### DIFF
--- a/scripts/dshbak
+++ b/scripts/dshbak
@@ -112,7 +112,7 @@ sub process_lines
 	while (<>) {
 		my ($tag, $data) = m/^\s*(\S+?)\s*: ?(.*\n)$/;
 		#  Ignore lines that aren't prefixed with a hostname:
-		next unless "$tag" ne "";
+		next unless defined $tag and "$tag" ne "";
 		push(@{$lines{$tag}}, $data);
 	}
 	return %lines;

--- a/tests/t5000-dshbak.sh
+++ b/tests/t5000-dshbak.sh
@@ -213,5 +213,10 @@ test_expect_success 'Issue 70: dshbak fails on hostname of 0' '
 2: bar
 " "[0-2]"
 '
+test_expect_success 'Issue 132: dshbak handles empty input' '
+  echo "" | dshbak -c >empty.output 2>&1 &&
+  touch empty.expected &&
+  test_cmp empty.expected empty.output
+'
 
 test_done


### PR DESCRIPTION
As described in #132 by @negregg, the fix for #70 inadvertently broke empty input in `dshbak`.

This PR adds a test to `t5000-dshbak.sh` to ensure empty input is handled by the script and then fixes the original fix.