### PR TITLE
add msg when module cannot load due to opt conflict

### DIFF
--- a/src/pdsh/mod.c
+++ b/src/pdsh/mod.c
@@ -302,8 +302,10 @@ _mod_destroy(mod_t mod)
 static bool
 _mod_opts_ok(mod_t mod)
 {
-    if (!opt_register(mod->pmod->opt_table))
+    if (!opt_register(mod->pmod->opt_table)) {
+        err("%p: Error loading module %s\n",mod->filename); 
         return false;
+    }
 
     return true;
 }

--- a/src/pdsh/opt.c
+++ b/src/pdsh/opt.c
@@ -205,7 +205,8 @@ bool opt_register(struct pdsh_module_option *opt_table)
     for (p = opt_table; p && (p->opt != 0); p++) {
         if (  (personality & p->personality) 
            && (strchr(pdsh_options, p->opt) != NULL)) {
-            err("%p: Option %c in use by an already loaded module.\n",opt_table->opt); 
+            err("%p: Option %c in use by an already loaded module.\n",p->opt);
+            err("%p: Options in use by modules are: %s\n", pdsh_options);
             return false;
 	}
     }

--- a/src/pdsh/opt.c
+++ b/src/pdsh/opt.c
@@ -204,8 +204,10 @@ bool opt_register(struct pdsh_module_option *opt_table)
      */
     for (p = opt_table; p && (p->opt != 0); p++) {
         if (  (personality & p->personality) 
-           && (strchr(pdsh_options, p->opt) != NULL))
+           && (strchr(pdsh_options, p->opt) != NULL)) {
+            err("%p: Option %c in use by an already loaded module.\n",opt_table->opt); 
             return false;
+	}
     }
 
     for (p = opt_table; p && (p->opt != 0); p++) {


### PR DESCRIPTION
- A customer may have a need for both DSH and genders
- However, 2 command options conflict and so the code rejects loading one of
the two modules.
- There is no error message provided in this state, so it is hard to
know what happened. In my case I had to use gdb to step through after
some break points to see that genders was failing to load because dsh used
two if the same command line options
- This change just provides a warning in this case instead of doing it
silently.