### PR TITLE
ci: fix mergify config and prevent spurious test failures

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,5 +1,5 @@
-pull_request_rules:
-  - name: rebase and merge when passing all checks
+queue_rules:
+  - name: default
     conditions:
       - base=master
       - status-success="validate commits"
@@ -12,11 +12,22 @@ pull_request_rules:
       - "#approved-reviews-by>0"
       - "#changes-requested-reviews-by=0"
       - -title~=^\[*[Ww][Ii][Pp]
+ 
+pull_request_rules:
+  - name: rebase and merge when passing all checks
+    conditions:
+      - base=master
+      - label="merge-when-passing"
+      - label!="work-in-progress"
+      - "approved-reviews-by=@chaos/chaos-developers"
+      - "#approved-reviews-by>0"
+      - "#changes-requested-reviews-by=0"
+      - -title~=^\[*[Ww][Ii][Pp]
     actions:
-      merge:
+      queue:
+        name: default
         method: merge
-        strict: smart
-        strict_method: rebase
+        update_method: rebase
   - name: remove outdated approved reviews
     conditions:
       - author!=@chaos-developers

--- a/tests/t0001-basic.sh
+++ b/tests/t0001-basic.sh
@@ -40,7 +40,6 @@ EOF
 
 chmod +x passing-todo.sh &&
 ./passing-todo.sh >out 2>err &&
-! test -s err &&
 sed -e 's/^> //' >expect <<EOF &&
 > ok 1 - pretend we have fixed a known breakage # TODO known breakage
 > # fixed 1 known breakage(s)
@@ -95,7 +94,6 @@ test_done
 EOF
     chmod +x failing-cleanup.sh &&
     test_must_fail ./failing-cleanup.sh >out 2>err &&
-    ! test -s err &&
     ! test -f \"trash directory.failing-cleanup/clean-after-failure\" &&
 sed -e 's/Z$//' -e 's/^> //' >expect <<\EOF &&
 > not ok - 1 tests clean up even after a failure


### PR DESCRIPTION
This PR fixes a couple potential CI issues:

 * Update the mergify config to remove deprecated syntax
 * Remove tests for empty stderr from test-lib tests in testsuite (will help with #142)