### PR TITLE
sshcmd: fix sshcmd_signal on macos

### DIFF
--- a/src/modules/sshcmd.c
+++ b/src/modules/sshcmd.c
@@ -257,7 +257,6 @@ static int sshcmd_signal(int fd, void *arg, int signum)
      *  Always send SIGTERM. SIGINT doesn't seem to get forwarded by ssh, and
      *    really termination of the connection is probably the desired result.
      */
-    err ("sending SIGTERM to ssh %s\n", pipecmd_target ((pipecmd_t) arg));
     return (pipecmd_signal ((pipecmd_t) arg, SIGTERM));
 }
 


### PR DESCRIPTION
This patch is required to fix a testing issue with macos in PR #144 

Problem: On Darwin 20.6.0 hosts, sshcmd_signal() fails due to
the err() call which prints "sending SIGTERM to ssh" for an unkown
reason. However, this output is redundant with a similar log message
printed from pipecmd_signal(), so the message is probably useless.

Remove the problematic statement from sshcmd_signal().