### PR TITLE
slurm: Call slurm_init() once before any call to Slurm API

### DIFF
--- a/src/modules/slurm.c
+++ b/src/modules/slurm.c
@@ -299,6 +299,20 @@ static hostlist_t _hl_append (hostlist_t hl, char *nodes)
     return (hl);
 }
 
+/*
+ * Make sure, slurm_init() is called before any call to the Slurm API
+ */
+static void _slurm_init() {
+  static bool _inited = false;
+
+  if (_inited)
+    return;
+#if SLURM_VERSION_NUMBER >= SLURM_VERSION_NUM(20,11,0)
+  slurm_init(NULL);
+#endif
+  _inited = true;
+}
+
 static hostlist_t _slurm_wcoll (List joblist)
 {
     int i;
@@ -310,6 +324,7 @@ static hostlist_t _slurm_wcoll (List joblist)
     if ((joblist == NULL) && (envjobid = _slurm_jobid()) < 0)
         return (NULL);
 
+    _slurm_init();
     if (slurm_load_jobs((time_t) NULL, &msg, SHOW_ALL) < 0) 
         errx ("Unable to contact slurm controller: %s\n", 
               slurm_strerror (errno));
@@ -359,6 +374,7 @@ static hostlist_t _slurm_wcoll_partition (List partitionlist)
     partition_info_t * p;
     ListIterator li;
 
+    _slurm_init();
     if (slurm_load_partitions((time_t) NULL, &msg, SHOW_ALL) < 0)
         errx ("Unable to contact slurm controller: %s\n",
               slurm_strerror (errno));
@@ -402,6 +418,7 @@ static hostlist_t _slurm_wcoll_constraint (hostlist_t wl, List constraintlist)
     char *c;
     ListIterator li;
 
+    _slurm_init();
     if (slurm_load_node((time_t) NULL, &msg, SHOW_ALL) < 0)
         errx ("Unable to contact slurm controller: %s\n",
               slurm_strerror (errno));

--- a/src/pdsh/opt.c
+++ b/src/pdsh/opt.c
@@ -527,6 +527,9 @@ void opt_args_early (opt_t * opt, int argc, char *argv[])
                     Free ((void **) &opt->misc_modules);
                 opt->misc_modules = Strdup (optarg);
                 break;
+            case 'd':              /* debug */
+                opt->debug = true;
+                break;
         }
     }
 #ifdef __linux
@@ -600,9 +603,6 @@ void opt_args(opt_t * opt, int argc, char *argv[])
             break;
         case 'S':              /* get remote command status */
             opt->ret_remote_rc = true;
-            break;
-        case 'd':              /* debug */
-            opt->debug = true;
             break;
         case 'f':              /* fanout */
             if (string_to_int (optarg, &opt->fanout) < 0)


### PR DESCRIPTION
Since Slurm 20.11, slurm_init() needs to be called before any call to the Slurm API to make sure the config file is read in. We cannot call it in mod_slurm_init() or in mod_slurm_wcoll() directly as it requires slurm to be configured before use, thus pdsh would fail whenever the slurm plugin is found but Slurm is not configured correctly.