### PR TITLE
log conflicting module options with -d (and other cleanup)

### DIFF
--- a/doc/pdcp.1.in
+++ b/doc/pdcp.1.in
@@ -183,7 +183,8 @@ List info on all loaded \fBpdcp\fR modules and quit.
 .TP
 .I "-d"
 Include more complete thread status when SIGINT is received, and display
-connect and command time statistics on stderr when done.
+connect and command time statistics on stderr when done. Also, display any
+module loading errors on stderr, include option conflicts.
 .TP
 .I "-V"
 Output \fBpdcp\fR version information, along with list of currently

--- a/doc/pdsh.1.in
+++ b/doc/pdsh.1.in
@@ -207,7 +207,8 @@ Disable hostname: prefix on lines of output.
 .TP
 .I "-d"
 Include more complete thread status when SIGINT is received, and display
-connect and command time statistics on stderr when done.
+connect and command time statistics on stderr when done. Also, display
+any module loading errors to stderr, including option conflicts.
 .TP
 .I "-V"
 Output \fBpdsh\fR version information, along with list of currently

--- a/src/common/err.c
+++ b/src/common/err.c
@@ -5,20 +5,20 @@
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Jim Garlick <garlick@llnl.gov>.
  *  UCRL-CODE-2003-005.
- *  
+ *
  *  This file is part of Pdsh, a parallel remote shell program.
  *  For details, see <http://www.llnl.gov/linux/pdsh/>.
- *  
+ *
  *  Pdsh is free software; you can redistribute it and/or modify it under
  *  the terms of the GNU General Public License as published by the Free
  *  Software Foundation; either version 2 of the License, or (at your option)
  *  any later version.
- *  
+ *
  *  Pdsh is distributed in the hope that it will be useful, but WITHOUT ANY
  *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
  *  details.
- *  
+ *
  *  You should have received a copy of the GNU General Public License along
  *  with Pdsh; if not, write to the Free Software Foundation, Inc.,
  *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
@@ -44,7 +44,7 @@
 
 #include "xstring.h"
 #include "xmalloc.h"
-#include "macros.h" 
+#include "macros.h"
 
 static char *prog = NULL;
 static char *host = NULL;
@@ -55,7 +55,7 @@ static char *host = NULL;
 static bool keep_host_domain = false;
 
 /*
- * Call this before calling err() or errx().  Sets hostname and program name 
+ * Call this before calling err() or errx().  Sets hostname and program name
  * for %H, %p, and %P.
  *   str (IN)	program name
  */
@@ -85,7 +85,7 @@ void err_cleanup(void)
     Free((void **) &host);
 }
 
-/* 
+/*
  * _verr() is like vfprintf, but handles (only) the following formats:
  * following formats:
  * %s	string
@@ -93,7 +93,7 @@ void err_cleanup(void)
  * %c	character
  * %m	string (sys_errlist[errno])
  * %d   int	
- * %z   equivalent to %.3d 
+ * %z   equivalent to %.3d
  * %p   program name with @host attached
  * %P   program name
  * %H   hostname for this host
@@ -115,8 +115,8 @@ static void _verr(FILE * stream, char *format, va_list ap)
                 xstrcat(&buf, va_arg(ap, char *));
             } else if (*format == 'S') {        /* %S - string, trunc */
                 snprintf(tmpstr, sizeof(tmpstr), "%s", va_arg(ap, char *));
-                if (  !isdigit(*tmpstr) 
-                   && !keep_host_domain 
+                if (  !isdigit(*tmpstr)
+                   && !keep_host_domain
                    && (q = strchr(tmpstr, '.')))
                     *q = '\0';
                 xstrcat(&buf, tmpstr);

--- a/src/common/err.h
+++ b/src/common/err.h
@@ -5,20 +5,20 @@
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Jim Garlick <garlick@llnl.gov>.
  *  UCRL-CODE-2003-005.
- *  
+ *
  *  This file is part of Pdsh, a parallel remote shell program.
  *  For details, see <http://www.llnl.gov/linux/pdsh/>.
- *  
+ *
  *  Pdsh is free software; you can redistribute it and/or modify it under
  *  the terms of the GNU General Public License as published by the Free
  *  Software Foundation; either version 2 of the License, or (at your option)
  *  any later version.
- *  
+ *
  *  Pdsh is distributed in the hope that it will be useful, but WITHOUT ANY
  *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
  *  details.
- *  
+ *
  *  You should have received a copy of the GNU General Public License along
  *  with Pdsh; if not, write to the Free Software Foundation, Inc.,
  *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.

--- a/src/common/fd.c
+++ b/src/common/fd.c
@@ -248,7 +248,7 @@ fd_null_read_n (int fd, void *buf, size_t n)
     ssize_t nread;
     unsigned char *p;
     unsigned char *q;
-                                                                                                  
+
     q = p = (unsigned char *)buf;
     nleft = n;
     while (nleft > 0) {

--- a/src/common/hostlist.c
+++ b/src/common/hostlist.c
@@ -5,20 +5,20 @@
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Mark Grondona <mgrondona@llnl.gov>
  *  UCRL-CODE-2002-040.
- *  
+ *
  *  This file is part of SLURM, a resource management program.
  *  For details, see <http://www.llnl.gov/linux/slurm/>.
- *  
+ *
  *  SLURM is free software; you can redistribute it and/or modify it under
  *  the terms of the GNU General Public License as published by the Free
  *  Software Foundation; either version 2 of the License, or (at your option)
  *  any later version.
- *  
+ *
  *  SLURM is distributed in the hope that it will be useful, but WITHOUT ANY
  *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
  *  details.
- *  
+ *
  *  You should have received a copy of the GNU General Public License along
  *  with SLURM; if not, write to the Free Software Foundation, Inc.,
  *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
@@ -87,7 +87,7 @@
         return(lsd_nomem_error(__FILE__, __LINE__, mesg));                   \
     } while (0)
 
-/* 
+/*
  * Some constants and tunables:
  */
 
@@ -317,7 +317,7 @@ static int hostset_find_host(hostset_t, const char *);
 #define UNLOCK_HOSTLIST(_hl)                                                 \
       do {                                                                   \
           mutex_unlock(&(_hl)->mutex);                                       \
-      } while (0)                       
+      } while (0)
 
 #define seterrno_ret(_errno, _rc)                                            \
       do {                                                                   \
@@ -341,7 +341,7 @@ static void _error(char *file, int line, char *msg, ...)
     va_start(ap, msg);
 
     len = vsnprintf(buf, 1024, msg, ap);
-    if ((len < 0) || (len > 1024)) 
+    if ((len < 0) || (len > 1024))
         buf[1023] = '\0';
 
     lsd_fatal_error(file, line, buf);
@@ -351,8 +351,8 @@ static void _error(char *file, int line, char *msg, ...)
 }
 
 
-/* 
- * Helper function for host list string parsing routines 
+/*
+ * Helper function for host list string parsing routines
  * Returns a pointer to the next token; additionally advance *str
  * to the next separator.
  *
@@ -384,7 +384,7 @@ static char * _next_tok(char *sep, char **str)
       else if ( **str == ']' ) level--;
       (*str)++;
     }
-    
+
    /* nullify consecutive separators and push str beyond them */
     while (**str != '\0' && strchr(sep, **str) != NULL)
         *(*str)++ = '\0';
@@ -404,12 +404,12 @@ static int _zero_padded(unsigned long num, int width)
 }
 
 /* test whether two format `width' parameters are "equivalent"
- * The width arguments "wn" and "wm" for integers "n" and "m" 
+ * The width arguments "wn" and "wm" for integers "n" and "m"
  * are equivalent if:
- *  
+ *
  *  o  wn == wm  OR
  *
- *  o  applying the same format width (either wn or wm) to both of  
+ *  o  applying the same format width (either wn or wm) to both of
  *     'n' and 'm' will not change the zero padding of *either* 'm' nor 'n'.
  *
  *  If this function returns 1 (or true), the appropriate width value
@@ -451,14 +451,14 @@ static int _width_equiv(unsigned long n, int *wn, unsigned long m, int *wm)
 
 /* ----[ hostname_t functions ]---- */
 
-/* 
+/*
  * return the location of the last char in the hostname prefix
  */
 static int host_prefix_end(const char *hostname)
 {
     int idx = strlen(hostname) - 1;
 
-    while (idx >= 0 && isdigit((char) hostname[idx])) 
+    while (idx >= 0 && isdigit((char) hostname[idx]))
         idx--;
     return idx;
 }
@@ -513,7 +513,7 @@ static hostname_t hostname_create_with_suffix (const char *hostname, int idx)
 }
 
 
-/* 
+/*
  * create a hostname_t object from a string hostname
  */
 static hostname_t hostname_create(const char *hostname)
@@ -536,7 +536,7 @@ static void hostname_destroy(hostname_t hn)
     free(hn);
 }
 
-/* return true if the hostname has a valid numeric suffix 
+/* return true if the hostname has a valid numeric suffix
  */
 static int hostname_suffix_is_valid(hostname_t hn)
 {
@@ -554,12 +554,12 @@ static int hostname_suffix_width(hostname_t hn)
 
 /* ----[ hostrange_t functions ]---- */
 
-/* allocate a new hostrange object 
+/* allocate a new hostrange object
  */
 static hostrange_t hostrange_new(void)
 {
     hostrange_t new = (hostrange_t) malloc(sizeof(*new));
-    if (!new) 
+    if (!new)
         out_of_memory("hostrange create");
     return new;
 }
@@ -689,7 +689,7 @@ static hostrange_t hostrange_delete_host(hostrange_t hr, unsigned long n)
 /* hostrange_cmp() is used to sort hostrange objects. It will
  * sort based on the following (in order):
  *  o result of strcmp on prefixes
- *  o if widths are compatible, then: 
+ *  o if widths are compatible, then:
  *       sort based on lowest suffix in range
  *    else
  *       sort based on width                     */
@@ -708,11 +708,11 @@ static int hostrange_cmp(hostrange_t h1, hostrange_t h2)
 }
 
 
-/* compare the prefixes of two hostrange objects. 
+/* compare the prefixes of two hostrange objects.
  * returns:
  *    < 0   if h1 prefix is less than h2 OR h1 == NULL.
  *
- *      0   if h1's prefix and h2's prefix match, 
+ *      0   if h1's prefix and h2's prefix match,
  *          UNLESS, either h1 or h2 (NOT both) do not have a valid suffix.
  *
  *    > 0   if h1's prefix is greater than h2's OR h2 == NULL. */
@@ -746,7 +746,7 @@ static int hostrange_within_range(hostrange_t h1, hostrange_t h2)
 }
 
 
-/* compare two hostrange objects to determine if they are width 
+/* compare two hostrange objects to determine if they are width
  * compatible,  returns:
  *  1 if widths can safely be combined
  *  0 if widths cannot be safely combined
@@ -784,10 +784,10 @@ static char *hostrange_pop(hostrange_t hr)
         hr->lo++;    /* effectively set count == 0 */
         host = strdup(hr->prefix);
     } else if (hostrange_count(hr) > 0) {
-        size = strlen(hr->prefix) + hr->width + 16;    
+        size = strlen(hr->prefix) + hr->width + 16;
         if (!(host = (char *) malloc(size * sizeof(char))))
             out_of_memory("hostrange pop");
-        snprintf(host, size, "%s%0*lu", hr->prefix, 
+        snprintf(host, size, "%s%0*lu", hr->prefix,
              hr->width, hr->hi--);
     }
 
@@ -824,7 +824,7 @@ static char *hostrange_shift(hostrange_t hr)
  *
  * -1 if ranges do not overlap (including incompatible zero padding)
  *  0 if ranges join perfectly
- * >0 number of hosts that were duplicated in  h1 and h2 
+ * >0 number of hosts that were duplicated in  h1 and h2
  *
  * h2 will be coalesced into h1 if rc >= 0
  *
@@ -878,7 +878,7 @@ static hostrange_t hostrange_intersect(hostrange_t h1, hostrange_t h2)
     assert(hostrange_cmp(h1, h2) <= 0);
 
     if ((hostrange_prefix_cmp(h1, h2) == 0)
-        && (h1->hi > h2->lo) 
+        && (h1->hi > h2->lo)
         && (hostrange_width_combine(h1, h2))) {
 
         if (!(new = hostrange_copy(h1)))
@@ -1041,7 +1041,7 @@ static size_t hostrange_numstr(hostrange_t hr, size_t n, char *buf)
 
     if ((len >= 0) && (len < n) && (hr->lo < hr->hi)) {
         int len2 = snprintf(buf+len, n-len, "-%0*lu", hr->width, hr->hi);
-        if (len2 < 0) 
+        if (len2 < 0)
             len = -1;
         else
             len += len2;
@@ -1053,7 +1053,7 @@ static size_t hostrange_numstr(hostrange_t hr, size_t n, char *buf)
 
 /* ----[ hostlist functions ]---- */
 
-/* Create a new hostlist object. 
+/* Create a new hostlist object.
  * Returns an empty hostlist, or NULL if memory allocation fails.
  */
 static hostlist_t hostlist_new(void)
@@ -1090,9 +1090,9 @@ static hostlist_t hostlist_new(void)
 /* Resize the internal array used to store the list of hostrange objects.
  *
  * returns 1 for a successful resize,
- *         0 if call to _realloc fails    
+ *         0 if call to _realloc fails
  *
- * It is assumed that the caller has the hostlist hl locked 
+ * It is assumed that the caller has the hostlist hl locked
  */
 static int hostlist_resize(hostlist_t hl, size_t newsize)
 {
@@ -1103,7 +1103,7 @@ static int hostlist_resize(hostlist_t hl, size_t newsize)
     oldsize = hl->size;
     hl->size = newsize;
     hl->hr = realloc((void *) hl->hr, hl->size*sizeof(hostrange_t));
-    if (!(hl->hr)) 
+    if (!(hl->hr))
         return 0;
 
     for (i = oldsize; i < newsize; i++)
@@ -1164,7 +1164,7 @@ static int hostlist_push_range(hostlist_t hl, hostrange_t hr)
 
 
 /* Same as hostlist_push_range() above, but prefix, lo, hi, and width
- * are passed as args 
+ * are passed as args
  */
 static int
 hostlist_push_hr(hostlist_t hl, char *prefix, unsigned long lo,
@@ -1276,23 +1276,23 @@ hostlist_t _hostlist_create(const char *hostlist, char *sep, char *r_op)
 
         high = low = 0;
 
-        /* find end of alpha part 
+        /* find end of alpha part
          *   do this by finding last occurence of range_op in str */
         pos = strlen(tok) - 1;
         if (strstr(tok, r_op) != '\0') {
-            while (pos >= 0 && (char) tok[pos] != range_op) 
+            while (pos >= 0 && (char) tok[pos] != range_op)
                 pos--;
         }
 
         /* now back up past any digits */
         while (pos >= 0 && isdigit((char) tok[--pos])) {;}
 
-        /* Check for valid x-y range (x must be a digit) 
+        /* Check for valid x-y range (x must be a digit)
          *   Reset pos if the range is not valid         */
         if (!isdigit((char) tok[++pos]))
             pos = strlen(tok) - 1;
 
-        /* create prefix string 
+        /* create prefix string
          * if prefix will be zero length, but prefix already exists
          * use the previous prefix and fmt
          */
@@ -1351,7 +1351,7 @@ hostlist_t _hostlist_create(const char *hostlist, char *sep, char *r_op)
             high = 0;    /* special case, ugh. */
         }
 
-        /* error if: 
+        /* error if:
          * 1. we are not at end of string
          * 2. upper bound equals lower bound
          */
@@ -1377,7 +1377,7 @@ hostlist_t _hostlist_create(const char *hostlist, char *sep, char *r_op)
 
 #else                /* !WANT_RECKLESS_HOSTRANGE_EXPANSION */
 
-hostlist_t _hostlist_create(const char *hostlist, char *sep, char *r_op) 
+hostlist_t _hostlist_create(const char *hostlist, char *sep, char *r_op)
 {
     return _hostlist_create_bracketed(hostlist, sep, r_op);
 }
@@ -1389,7 +1389,7 @@ struct _range {
     int width;
 };
 
-/* Grab a single range from str 
+/* Grab a single range from str
  * returns 1 if str contained a valid number or range,
  *         0 if conversion of str to a range failed.
  */
@@ -1397,7 +1397,7 @@ static int _parse_single_range(const char *str, struct _range *range)
 {
     char *p, *q;
     char *orig = strdup(str);
-    if (!orig) 
+    if (!orig)
         seterrno_ret(ENOMEM, 0);
 
     if ((p = strchr(str, '-'))) {
@@ -1406,15 +1406,15 @@ static int _parse_single_range(const char *str, struct _range *range)
             goto error;
     }
     range->lo = strtoul(str, &q, 10);
-    if (q == str) 
+    if (q == str)
         goto error;
 
     range->hi = (p && *p) ? strtoul(p, &q, 10) : range->lo;
 
-    if (q == p || *q != '\0') 
+    if (q == p || *q != '\0')
         goto error;
 
-    if (range->lo > range->hi) 
+    if (range->lo > range->hi)
         goto error;
 
     if (range->hi - range->lo + 1 > MAX_RANGE ) {
@@ -1436,7 +1436,7 @@ static int _parse_single_range(const char *str, struct _range *range)
 
 /*
  * Convert 'str' containing comma separated digits and ranges into an array
- *  of struct _range types (max 'len' elements).  
+ *  of struct _range types (max 'len' elements).
  *
  * Return number of ranges created, or -1 on error.
  */
@@ -1450,8 +1450,8 @@ static int _parse_range_list(char *str, struct _range *ranges, int len)
             return -1;
         if ((p = strchr(str, ',')))
             *p++ = '\0';
-        if (!_parse_single_range(str, &ranges[count++])) 
-            return -1;  
+        if (!_parse_single_range(str, &ranges[count++]))
+            return -1;
         str = p;
     }
     return count;
@@ -1469,7 +1469,7 @@ _push_range_list(hostlist_t hl, char *pfx, struct _range *rng,
 }
 
 static void
-_push_range_list_with_suffix(hostlist_t hl, char *pfx, char *sfx, 
+_push_range_list_with_suffix(hostlist_t hl, char *pfx, char *sfx,
                              struct _range *rng, int n)
 {
     int i;
@@ -1491,10 +1491,10 @@ _push_range_list_with_suffix(hostlist_t hl, char *pfx, char *sfx,
 }
 
 /*
- * Create a hostlist from a string with brackets '[' ']' to aid 
+ * Create a hostlist from a string with brackets '[' ']' to aid
  * detection of ranges and compressed lists
  */
-static hostlist_t 
+static hostlist_t
 _hostlist_create_bracketed(const char *hostlist, char *sep, char *r_op)
 {
     hostlist_t new = hostlist_new();
@@ -1521,7 +1521,7 @@ _hostlist_create_bracketed(const char *hostlist, char *sep, char *r_op)
             if ((q = strchr(p, ']'))) {
                 *q = '\0';
                 nr = _parse_range_list(p, ranges, MAX_RANGES);
-                if (nr < 0) 
+                if (nr < 0)
                     goto error;
 
                 if (*(++q) != '\0')
@@ -1529,7 +1529,7 @@ _hostlist_create_bracketed(const char *hostlist, char *sep, char *r_op)
                 else
                     _push_range_list(new, prefix, ranges, nr);
 
-                
+
             } else
                 hostlist_push_host(new, cur_tok);
 
@@ -1679,7 +1679,7 @@ char *hostlist_pop(hostlist_t hl)
     return host;
 }
 
-/* find all iterators affected by a shift (or deletion) at 
+/* find all iterators affected by a shift (or deletion) at
  * hl->hr[idx], depth, with the deletion of n ranges */
 static void
 hostlist_shift_iterators(hostlist_t hl, int idx, int depth, int n)
@@ -1778,7 +1778,7 @@ char *hostlist_shift_range(hostlist_t hl)
     do {
         hostlist_push_range(hltmp, hl->hr[i]);
         hostrange_destroy(hl->hr[i]);
-    } while ( (++i < hl->nranges) 
+    } while ( (++i < hl->nranges)
             && hostrange_within_range(hltmp->hr[0], hl->hr[i]) );
 
     hostlist_shift_iterators(hl, i, 0, hltmp->nranges);
@@ -1836,7 +1836,7 @@ _hostrange_string(hostrange_t hr, int depth)
     int  len = snprintf(buf, MAXHOSTNAMELEN + 15, "%s", hr->prefix);
 
     if (!hr->singlehost)
-        snprintf(buf+len, MAXHOSTNAMELEN+15 - len, "%0*lu", 
+        snprintf(buf+len, MAXHOSTNAMELEN+15 - len, "%0*lu",
                  hr->width, hr->lo + depth);
     return strdup(buf);
 }
@@ -1937,7 +1937,7 @@ int hostlist_find(hostlist_t hl, const char *hostname)
     return ret;
 }
 
-/* hostrange compare with void * arguments to allow use with 
+/* hostrange compare with void * arguments to allow use with
  * libc qsort()
  */
 int _cmp(const void *hr1, const void *hr2)
@@ -1971,7 +1971,7 @@ void hostlist_sort(hostlist_t hl)
 }
 
 
-/* search through hostlist for ranges that can be collapsed 
+/* search through hostlist for ranges that can be collapsed
  * does =not= delete any hosts
  */
 static void hostlist_collapse(hostlist_t hl)
@@ -1993,7 +1993,7 @@ static void hostlist_collapse(hostlist_t hl)
     UNLOCK_HOSTLIST(hl);
 }
 
-/* search through hostlist (hl) for intersecting ranges 
+/* search through hostlist (hl) for intersecting ranges
  * split up duplicates and coalesce ranges where possible
  */
 static void hostlist_coalesce(hostlist_t hl)
@@ -2208,7 +2208,7 @@ ssize_t hostlist_ranged_string(hostlist_t hl, size_t n, char *buf)
 static hostlist_iterator_t hostlist_iterator_new(void)
 {
     hostlist_iterator_t i = (hostlist_iterator_t) malloc(sizeof(*i));
-    if (!i) 
+    if (!i)
         return NULL;
     i->hl = NULL;
     i->hr = NULL;
@@ -2327,7 +2327,7 @@ char *hostlist_next(hostlist_iterator_t i)
     len = strlen (i->hr->prefix) + strlen (suffix) + 1;
     if (!(buf = malloc (len)))
         out_of_memory("hostlist_next");
-    
+
     buf[0] = '\0';
     strcat (buf, i->hr->prefix);
     strcat (buf, suffix);
@@ -2428,9 +2428,9 @@ void hostset_destroy(hostset_t set)
     free(set);
 }
 
-/* inserts a single range object into a hostset 
+/* inserts a single range object into a hostset
  * Assumes that the set->hl lock is already held
- * Updates hl->nhosts 
+ * Updates hl->nhosts
  */
 static int hostset_insert_range(hostset_t set, hostrange_t hr)
 {
@@ -2450,7 +2450,7 @@ static int hostset_insert_range(hostset_t set, hostrange_t hr)
     for (i = 0; i < hl->nranges; i++) {
         if (hostrange_cmp(hr, hl->hr[i]) <= 0) {
 
-            if ((ndups = hostrange_join(hr, hl->hr[i])) >= 0) 
+            if ((ndups = hostrange_join(hr, hl->hr[i])) >= 0)
                 hostlist_delete_range(hl, i);
             else if (ndups < 0)
                 ndups = 0;
@@ -2476,10 +2476,10 @@ static int hostset_insert_range(hostset_t set, hostrange_t hr)
             if ((ndups = _attempt_range_join(hl, hl->nranges - 1)) <= 0)
                 ndups = 0;
         }
-    } 
+    }
 
-    /* 
-     *  Return the number of unique hosts inserted 
+    /*
+     *  Return the number of unique hosts inserted
      */
     return nhosts - ndups;
 }
@@ -2493,7 +2493,7 @@ int hostset_insert(hostset_t set, const char *hosts)
 
     hostlist_uniq(hl);
     LOCK_HOSTLIST(set->hl);
-    for (i = 0; i < hl->nranges; i++) 
+    for (i = 0; i < hl->nranges; i++)
         n += hostset_insert_range(set, hl->hr[i]);
     UNLOCK_HOSTLIST(set->hl);
     hostlist_destroy(hl);
@@ -2591,7 +2591,7 @@ ssize_t hostset_deranged_string(hostset_t set, size_t n, char *buf)
     return hostlist_deranged_string(set->hl, n, buf);
 }
 
-#if TEST_MAIN 
+#if TEST_MAIN
 
 int hostlist_nranges(hostlist_t hl)
 {
@@ -2742,6 +2742,6 @@ int main(int ac, char **av)
 
 #endif                /* TEST_MAIN */
 
-/* 
- * vi: tabstop=4 shiftwidth=4 expandtab 
+/*
+ * vi: tabstop=4 shiftwidth=4 expandtab
  */

--- a/src/common/hostlist.c
+++ b/src/common/hostlist.c
@@ -1512,7 +1512,7 @@ _hostlist_create_bracketed(const char *hostlist, char *sep, char *r_op)
     }
 
     while ((tok = _next_tok(sep, &str)) != NULL) {
-        strncpy(cur_tok, tok, 1024);
+        strncpy(cur_tok, tok, 1023);
 
         if ((p = strchr(tok, '[')) != NULL) {
             char *q, *prefix = tok;

--- a/src/common/hostlist.h
+++ b/src/common/hostlist.h
@@ -7,20 +7,20 @@
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Mark Grondona <mgrondona@llnl.gov>
  *  UCRL-CODE-2002-040.
- *  
+ *
  *  This file is part of SLURM, a resource management program.
  *  For details, see <http://www.llnl.gov/linux/slurm/>.
- *  
+ *
  *  SLURM is free software; you can redistribute it and/or modify it under
  *  the terms of the GNU General Public License as published by the Free
  *  Software Foundation; either version 2 of the License, or (at your option)
  *  any later version.
- *  
+ *
  *  SLURM is distributed in the hope that it will be useful, but WITHOUT ANY
  *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
  *  details.
- *  
+ *
  *  You should have received a copy of the GNU General Public License along
  *  with SLURM; if not, write to the Free Software Foundation, Inc.,
  *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
@@ -42,7 +42,7 @@
  *    #define lsd_fatal_error(file,line,mesg)  \
  *              error("%s:%s %s\n",file,line,mesg);
  *
- * If WITH_LSD_NOMEM_ERROR_FUNC is defined, the linker will expect to 
+ * If WITH_LSD_NOMEM_ERROR_FUNC is defined, the linker will expect to
  * find an external lsd_nomem_error(file,line,mesg) function. By default,
  * lsd_nomem_error(file,line,mesg) is a macro definition that returns NULL.
  * This macro may be redefined to invoke another routine instead.
@@ -51,9 +51,9 @@
  *
  */
 
-/* The hostlist opaque data type 
+/* The hostlist opaque data type
  *
- * A hostlist is a list of hostnames optimized for a prefixXXXX style 
+ * A hostlist is a list of hostnames optimized for a prefixXXXX style
  * naming convention, where XXXX  is a decimal, numeric suffix.
  */
 typedef struct hostlist * hostlist_t;
@@ -61,7 +61,7 @@ typedef struct hostlist * hostlist_t;
 /* A hostset is a special case of a hostlist. It:
  *
  * 1. never contains duplicates
- * 2. is always sorted 
+ * 2. is always sorted
  *    (Note: sort occurs first on alphanumeric prefix -- where prefix
  *     matches, numeric suffixes will be sorted *by value*)
  */
@@ -69,7 +69,7 @@ typedef struct hostset * hostset_t;
 
 /* The hostlist iterator type (may be used with a hostset as well)
  * used for non-destructive access to hostlist members.
- * 
+ *
  */
 typedef struct hostlist_iterator * hostlist_iterator_t;
 
@@ -78,25 +78,25 @@ typedef struct hostlist_iterator * hostlist_iterator_t;
 /* ----[ hostlist creation and destruction ]---- */
 
 /*
- * hostlist_create(): 
+ * hostlist_create():
  *
- * Create a new hostlist from a string representation. 
+ * Create a new hostlist from a string representation.
  *
  * The string representation (str) may contain one or more hostnames or
- * bracketed hostlists separated by either `,' or whitespace. A bracketed 
- * hostlist is denoted by a common prefix followed by a list of numeric 
- * ranges contained within brackets: e.g. "tux[0-5,12,20-25]" 
+ * bracketed hostlists separated by either `,' or whitespace. A bracketed
+ * hostlist is denoted by a common prefix followed by a list of numeric
+ * ranges contained within brackets: e.g. "tux[0-5,12,20-25]"
  *
  * Note: if this module is compiled with WANT_RECKLESS_HOSTRANGE_EXPANSION
- * defined, a much more loose interpretation of host ranges is used. 
- * Reckless hostrange expansion allows all of the following (in addition to 
+ * defined, a much more loose interpretation of host ranges is used.
+ * Reckless hostrange expansion allows all of the following (in addition to
  * bracketed hostlists):
  *
  *  o tux0-5,tux12,tux20-25
  *  o tux0-tux5,tux12,tux20-tux25
  *  o tux0-5,12,20-25
  *
- * If str is NULL, and empty hostlist is created and returned. 
+ * If str is NULL, and empty hostlist is created and returned.
  *
  * If the create fails, hostlist_create() returns NULL.
  *
@@ -105,7 +105,7 @@ typedef struct hostlist_iterator * hostlist_iterator_t;
  */
 hostlist_t hostlist_create(const char *hostlist);
 
-/* hostlist_copy(): 
+/* hostlist_copy():
  *
  * Allocate a copy of a hostlist object. Returned hostlist must be freed
  * with hostlist_destroy.
@@ -127,7 +127,7 @@ void hostlist_destroy(hostlist_t hl);
  *
  * The hosts argument may take the same form as in hostlist_create()
  *
- * Returns the number of hostnames inserted into the list, 
+ * Returns the number of hostnames inserted into the list,
  * or 0 on failure.
  */
 int hostlist_push(hostlist_t hl, const char *hosts);
@@ -135,7 +135,7 @@ int hostlist_push(hostlist_t hl, const char *hosts);
 
 /* hostlist_push_host():
  *
- * Push a single host onto the hostlist hl. 
+ * Push a single host onto the hostlist hl.
  * This function is more efficient than hostlist_push() for a single
  * hostname, since the argument does not need to be checked for ranges.
  *
@@ -203,8 +203,8 @@ char * hostlist_shift_range(hostlist_t hl);
 
 /* hostlist_find():
  *
- * Searches hostlist hl for the first host matching hostname 
- * and returns position in list if found. 
+ * Searches hostlist hl for the first host matching hostname
+ * and returns position in list if found.
  *
  * Returns -1 if host is not found.
  *
@@ -223,7 +223,7 @@ int hostlist_delete(hostlist_t hl, const char *hosts);
 /* hostlist_delete_host():
  *
  * Deletes the first host that matches `hostname' from the hostlist hl.
- * Note: "hostname" argument cannot contain a range of hosts 
+ * Note: "hostname" argument cannot contain a range of hosts
  *       (see hostlist_delete() for this functionality.)
  *
  * Returns 1 if successful, 0 if hostname is not found in list.
@@ -244,7 +244,7 @@ int hostlist_delete_nth(hostlist_t hl, int n);
 /* hostlist_count():
  *
  * Return the number of hosts in hostlist hl.
- */ 
+ */
 int hostlist_count(hostlist_t hl);
 
 /* hostlist_is_empty(): return true if hostlist is empty. */
@@ -253,7 +253,7 @@ int hostlist_count(hostlist_t hl);
 /* ----[ Other hostlist operations ]---- */
 
 /* hostlist_sort():
- * 
+ *
  * Sort the hostlist hl.
  *
  */
@@ -262,7 +262,7 @@ void hostlist_sort(hostlist_t hl);
 /* hostlist_uniq():
  *
  * Sort the hostlist hl and remove duplicate entries.
- * 
+ *
  */
 void hostlist_uniq(hostlist_t hl);
 
@@ -276,7 +276,7 @@ void hostlist_uniq(hostlist_t hl);
  * or -1 if truncation occurred.
  *
  * The result will be NULL terminated.
- * 
+ *
  * hostlist_ranged_string() will write a bracketed hostlist representation
  * where possible.
  */
@@ -336,11 +336,11 @@ void hostlist_iterator_reset(hostlist_iterator_t i);
 
 /* hostlist_next():
  *
- * Returns a pointer to the  next hostname on the hostlist 
+ * Returns a pointer to the  next hostname on the hostlist
  * or NULL at the end of the list
  *
  * The caller is responsible for freeing the returned memory.
- */ 
+ */
 char * hostlist_next(hostlist_iterator_t i);
 
 

--- a/src/common/list.c
+++ b/src/common/list.c
@@ -6,7 +6,7 @@
  *  Copyright (C) 2001-2006 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Chris Dunlap <cdunlap@llnl.gov>.
- *  
+ *
  *  This file is from LSD-Tools, the LLNL Software Development Toolbox.
  *
  *  LSD-Tools is free software; you can redistribute it and/or modify it under

--- a/src/common/list.h
+++ b/src/common/list.h
@@ -6,7 +6,7 @@
  *  Copyright (C) 2001-2002 The Regents of the University of California.
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Chris Dunlap <cdunlap@llnl.gov>.
- *  
+ *
  *  This file is from LSD-Tools, the LLNL Software Development Toolbox.
  *
  *  LSD-Tools is free software; you can redistribute it and/or modify it under

--- a/src/common/macros.h
+++ b/src/common/macros.h
@@ -5,20 +5,20 @@
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Jim Garlick <garlick@llnl.gov>.
  *  UCRL-CODE-2003-005.
- *  
+ *
  *  This file is part of Pdsh, a parallel remote shell program.
  *  For details, see <http://www.llnl.gov/linux/pdsh/>.
- *  
+ *
  *  Pdsh is free software; you can redistribute it and/or modify it under
  *  the terms of the GNU General Public License as published by the Free
  *  Software Foundation; either version 2 of the License, or (at your option)
  *  any later version.
- *  
+ *
  *  Pdsh is distributed in the hope that it will be useful, but WITHOUT ANY
  *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
  *  details.
- *  
+ *
  *  You should have received a copy of the GNU General Public License along
  *  with Pdsh; if not, write to the Free Software Foundation, Inc.,
  *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.

--- a/src/common/pipecmd.c
+++ b/src/common/pipecmd.c
@@ -5,20 +5,20 @@
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Jim Garlick <garlick@llnl.gov>.
  *  UCRL-CODE-2003-005.
- *  
+ *
  *  This file is part of Pdsh, a parallel remote shell program.
  *  For details, see <http://www.llnl.gov/linux/pdsh/>.
- *  
+ *
  *  Pdsh is free software; you can redistribute it and/or modify it under
  *  the terms of the GNU General Public License as published by the Free
  *  Software Foundation; either version 2 of the License, or (at your option)
  *  any later version.
- *  
+ *
  *  Pdsh is distributed in the hope that it will be useful, but WITHOUT ANY
  *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
  *  details.
- *  
+ *
  *  You should have received a copy of the GNU General Public License along
  *  with Pdsh; if not, write to the Free Software Foundation, Inc.,
  *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
@@ -59,7 +59,7 @@ struct pipe_info_struct {
 
 static int _pipecmd (char *path, char *args[], int *fd2p, pid_t *ppid);
 
-pipecmd_t pipe_info_create (const char *path, const char *target, 
+pipecmd_t pipe_info_create (const char *path, const char *target,
         const char *user, int rank)
 {
     struct pipe_info_struct *e = Malloc (sizeof (*e));
@@ -120,7 +120,7 @@ static char * pipecmd_format_arg (pipecmd_t e, const char *arg)
                     break;
             }
         }
-        else 
+        else
             xstrcatchar (&str, *p);
         p++;
     }
@@ -145,7 +145,7 @@ static char ** cmd_args_create (pipecmd_t e, const char **argv)
      *  Cmd should be args[0]:
      */
     args [0] = Strdup (e->cmd);
-    for (i = 1; i < n+1; i++) 
+    for (i = 1; i < n+1; i++)
         args[i] = pipecmd_format_arg (e, argv[i-1]);
 
     args[i] = NULL;
@@ -207,7 +207,7 @@ int pipecmd_signal (pipecmd_t p, int signo)
 
     if (p == NULL)
         return (-1);
-   
+
     cmd =  xbasename (p->path);
     err ("sending signal %d to %s [%s] pid %d\n", signo, p->target, cmd,
             p->pid);
@@ -223,7 +223,7 @@ int pipecmd_wait (pipecmd_t p, int *pstatus)
         return (-1);
 
     if (waitpid (p->pid, &status, 0) < 0)
-        err ("%p: %S: %s pid %ld: waitpid: %m\n", p->target, 
+        err ("%p: %S: %s pid %ld: waitpid: %m\n", p->target,
                 xbasename (p->path), p->pid);
 
     if (status != 0) {

--- a/src/common/pipecmd.h
+++ b/src/common/pipecmd.h
@@ -5,20 +5,20 @@
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Jim Garlick <garlick@llnl.gov>.
  *  UCRL-CODE-2003-005.
- *  
+ *
  *  This file is part of Pdsh, a parallel remote shell program.
  *  For details, see <http://www.llnl.gov/linux/pdsh/>.
- *  
+ *
  *  Pdsh is free software; you can redistribute it and/or modify it under
  *  the terms of the GNU General Public License as published by the Free
  *  Software Foundation; either version 2 of the License, or (at your option)
  *  any later version.
- *  
+ *
  *  Pdsh is distributed in the hope that it will be useful, but WITHOUT ANY
  *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
  *  details.
- *  
+ *
  *  You should have received a copy of the GNU General Public License along
  *  with Pdsh; if not, write to the Free Software Foundation, Inc.,
  *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
@@ -34,10 +34,10 @@ typedef struct pipe_info_struct * pipecmd_t;
  *   pipes available to pdsh.
  *  Args are re-formatted replacing %h, %u, and %n with
  *   remote "host", user, and "rank" respectively.
- * 
+ *
  *  Returns NULL pipecmd object on failure.
  */
-pipecmd_t pipecmd (const char *path, const char **args, 
+pipecmd_t pipecmd (const char *path, const char **args,
         const char *target, const char *user, int rank);
 
 /*

--- a/src/common/split.c
+++ b/src/common/split.c
@@ -5,20 +5,20 @@
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Jim Garlick <garlick@llnl.gov>.
  *  UCRL-CODE-2003-005.
- *  
+ *
  *  This file is part of Pdsh, a parallel remote shell program.
  *  For details, see <http://www.llnl.gov/linux/pdsh/>.
- *  
+ *
  *  Pdsh is free software; you can redistribute it and/or modify it under
  *  the terms of the GNU General Public License as published by the Free
  *  Software Foundation; either version 2 of the License, or (at your option)
  *  any later version.
- *  
+ *
  *  Pdsh is distributed in the hope that it will be useful, but WITHOUT ANY
  *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
  *  details.
- *  
+ *
  *  You should have received a copy of the GNU General Public License along
  *  with Pdsh; if not, write to the Free Software Foundation, Inc.,
  *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
@@ -34,10 +34,10 @@
 #include "xmalloc.h"
 #include "split.h"
 
-/* 
- * Helper function for list_split(). Extract tokens from str.  
- * Return a pointer to the next token; at the same time, advance 
- * *str to point to the next separator.  
+/*
+ * Helper function for list_split(). Extract tokens from str.
+ * Return a pointer to the next token; at the same time, advance
+ * *str to point to the next separator.
  *   sep (IN)   string containing list of separator characters
  *   str (IN)   double-pointer to string containing tokens and separators
  *   RETURN next token
@@ -127,18 +127,18 @@ int list_join (char *result, size_t len, const char *sep, List l)
     ListIterator i;
 
     memset (result, 0, len);
-        
+
     if (list_count(l) == 0)
         return (0);
-        
+
     i = list_iterator_create(l);
     while ((str = list_next(i))) {
         int count;
-            
-        if (!truncated)  {
-            count = snprintf(result + n, len - n, "%s%s", str, sep); 
 
-            if ((count >= (len - n)) || (count < 0)) 
+        if (!truncated)  {
+            count = snprintf(result + n, len - n, "%s%s", str, sep);
+
+            if ((count >= (len - n)) || (count < 0))
                 truncated = 1;
             else
                 n += count;
@@ -151,7 +151,7 @@ int list_join (char *result, size_t len, const char *sep, List l)
     if (truncated)
         result [len - 1] = '\0';
     else {
-        /* 
+        /*
          * Delete final separator
          */
         result[strlen(result) - strlen(sep)] = '\0';

--- a/src/common/split.h
+++ b/src/common/split.h
@@ -5,20 +5,20 @@
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Jim Garlick <garlick@llnl.gov>.
  *  UCRL-CODE-2003-005.
- *  
+ *
  *  This file is part of Pdsh, a parallel remote shell program.
  *  For details, see <http://www.llnl.gov/linux/pdsh/>.
- *  
+ *
  *  Pdsh is free software; you can redistribute it and/or modify it under
  *  the terms of the GNU General Public License as published by the Free
  *  Software Foundation; either version 2 of the License, or (at your option)
  *  any later version.
- *  
+ *
  *  Pdsh is distributed in the hope that it will be useful, but WITHOUT ANY
  *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
  *  details.
- *  
+ *
  *  You should have received a copy of the GNU General Public License along
  *  with Pdsh; if not, write to the Free Software Foundation, Inc.,
  *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.

--- a/src/common/xmalloc.c
+++ b/src/common/xmalloc.c
@@ -5,20 +5,20 @@
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Jim Garlick <garlick@llnl.gov>.
  *  UCRL-CODE-2003-005.
- *  
+ *
  *  This file is part of Pdsh, a parallel remote shell program.
  *  For details, see <http://www.llnl.gov/linux/pdsh/>.
- *  
+ *
  *  Pdsh is free software; you can redistribute it and/or modify it under
  *  the terms of the GNU General Public License as published by the Free
  *  Software Foundation; either version 2 of the License, or (at your option)
  *  any later version.
- *  
+ *
  *  Pdsh is distributed in the hope that it will be useful, but WITHOUT ANY
  *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
  *  details.
- *  
+ *
  *  You should have received a copy of the GNU General Public License along
  *  with Pdsh; if not, write to the Free Software Foundation, Inc.,
  *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
@@ -73,7 +73,7 @@ void *Malloc(size_t size)
     return new;
 }
 
-/* 
+/*
  * "Safe" version of realloc().  Args are different: pass in a pointer to
  * the object to be realloced instead of the object itself.
  *   item (IN/OUT)	double-pointer to allocated space
@@ -129,7 +129,7 @@ int Size(void *item)
     return p[1];
 }
 
-/* 
+/*
  * Free which takes a pointer to object to free, which it turns into a null
  * object.
  *   item (IN/OUT)	double-pointer to allocated space

--- a/src/common/xmalloc.h
+++ b/src/common/xmalloc.h
@@ -5,20 +5,20 @@
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Jim Garlick <garlick@llnl.gov>.
  *  UCRL-CODE-2003-005.
- *  
+ *
  *  This file is part of Pdsh, a parallel remote shell program.
  *  For details, see <http://www.llnl.gov/linux/pdsh/>.
- *  
+ *
  *  Pdsh is free software; you can redistribute it and/or modify it under
  *  the terms of the GNU General Public License as published by the Free
  *  Software Foundation; either version 2 of the License, or (at your option)
  *  any later version.
- *  
+ *
  *  Pdsh is distributed in the hope that it will be useful, but WITHOUT ANY
  *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
  *  details.
- *  
+ *
  *  You should have received a copy of the GNU General Public License along
  *  with Pdsh; if not, write to the Free Software Foundation, Inc.,
  *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.

--- a/src/common/xpoll.c
+++ b/src/common/xpoll.c
@@ -5,20 +5,20 @@
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Jim Garlick <garlick@llnl.gov>.
  *  UCRL-CODE-2003-005.
- *  
+ *
  *  This file is part of Pdsh, a parallel remote shell program.
  *  For details, see <http://www.llnl.gov/linux/pdsh/>.
- *  
+ *
  *  Pdsh is free software; you can redistribute it and/or modify it under
  *  the terms of the GNU General Public License as published by the Free
  *  Software Foundation; either version 2 of the License, or (at your option)
  *  any later version.
- *  
+ *
  *  Pdsh is distributed in the hope that it will be useful, but WITHOUT ANY
  *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
  *  details.
- *  
+ *
  *  You should have received a copy of the GNU General Public License along
  *  with Pdsh; if not, write to the Free Software Foundation, Inc.,
  *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
@@ -26,7 +26,7 @@
 
 #if HAVE_CONFIG_H
 #  include <config.h>
-#endif 
+#endif
 
 #if HAVE_POLL_H
 #include <poll.h>
@@ -50,7 +50,7 @@
 #include "xmalloc.h"
 
 #if HAVE_POLL
-static int 
+static int
 _poll(struct xpollfd *xfds, unsigned int nfds, int timeout) {
     int i, rv;
     struct pollfd *pfds = Malloc(nfds * sizeof(struct pollfd));
@@ -58,7 +58,7 @@ _poll(struct xpollfd *xfds, unsigned int nfds, int timeout) {
     for (i = 0; i < nfds; i++) {
         pfds[i].fd = xfds[i].fd;
         pfds[i].events = 0;
-        pfds[i].revents = 0; 
+        pfds[i].revents = 0;
 
         if (xfds[i].events & XPOLLREAD)
             pfds[i].events |= POLLIN;
@@ -81,7 +81,7 @@ _poll(struct xpollfd *xfds, unsigned int nfds, int timeout) {
         if (pfds[i].revents & POLLNVAL)
             xfds[i].revents |= XPOLLINVAL;
     }
-    
+
     Free((void **)&pfds);
     errno = 0;
     return rv;
@@ -89,7 +89,7 @@ _poll(struct xpollfd *xfds, unsigned int nfds, int timeout) {
 
 #else /* !HAVE_POLL */
 
-static int 
+static int
 _select(struct xpollfd *xfds, unsigned int nfds, int timeout) {
     int i, maxfd = -1, inval = 0, rv = -1;
     struct timeval tv;
@@ -108,7 +108,7 @@ _select(struct xpollfd *xfds, unsigned int nfds, int timeout) {
     FD_ZERO(&writes);
     for (i = 0; i < nfds; i++) {
         if (xfds[i].fd >= FD_SETSIZE || xfds[i].fd < 0) {
-            xfds[i].revents |= XPOLLINVAL; 
+            xfds[i].revents |= XPOLLINVAL;
             inval++;
             continue;
         }
@@ -167,7 +167,7 @@ _select(struct xpollfd *xfds, unsigned int nfds, int timeout) {
 
     for (i = 0; i < nfds; i++) {
         /* protect segfault prone FD_ISSET */
-        if (xfds[i].revents & XPOLLINVAL)  
+        if (xfds[i].revents & XPOLLINVAL)
             continue;
 
         if (FD_ISSET(xfds[i].fd, &reads))
@@ -175,7 +175,7 @@ _select(struct xpollfd *xfds, unsigned int nfds, int timeout) {
         if (FD_ISSET(xfds[i].fd, &writes))
             xfds[i].revents |= XPOLLWRITE;
     }
-    
+
     errno = 0;
     return (rv + inval);
 }
@@ -189,7 +189,7 @@ int xpoll(struct xpollfd *xfds, int nfds, int timeout) {
     if (xfds == NULL || nfds <= 0) {
         errno = EINVAL;
         return -1;
-    }  
+    }
 
     for (i = 0; i < nfds; i++) {
         xfds[i].revents = 0;
@@ -199,9 +199,9 @@ int xpoll(struct xpollfd *xfds, int nfds, int timeout) {
     return _poll(xfds, nfds, timeout);
 #else
     return _select(xfds, nfds, timeout);
-#endif     
+#endif
 }
-   
+
 /*
  * vi: tabstop=4 shiftwidth=4 expandtab
  */

--- a/src/common/xpoll.h
+++ b/src/common/xpoll.h
@@ -5,20 +5,20 @@
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Jim Garlick <garlick@llnl.gov>.
  *  UCRL-CODE-2003-005.
- *  
+ *
  *  This file is part of Pdsh, a parallel remote shell program.
  *  For details, see <http://www.llnl.gov/linux/pdsh/>.
- *  
+ *
  *  Pdsh is free software; you can redistribute it and/or modify it under
  *  the terms of the GNU General Public License as published by the Free
  *  Software Foundation; either version 2 of the License, or (at your option)
  *  any later version.
- *  
+ *
  *  Pdsh is distributed in the hope that it will be useful, but WITHOUT ANY
  *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
  *  details.
- *  
+ *
  *  You should have received a copy of the GNU General Public License along
  *  with Pdsh; if not, write to the Free Software Foundation, Inc.,
  *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
@@ -43,8 +43,8 @@ struct xpollfd {
 
 /*
  * xpoll()
- * - Wrapper API around poll() and select().  
- * 
+ * - Wrapper API around poll() and select().
+ *
  * Input:
  * xfds - pointer to array of xfds structures
  * nfds - number of structures in xfds array
@@ -61,8 +61,8 @@ struct xpollfd {
  * - Any invalid bits stored in events are ignored
  * - revents is cleared before any revents are set
  * - XPOLLINVAL and XPOLLERR are not mutually exclusive with
- *   XPOLLREAD and XPOLLWRITE.  
- */ 
+ *   XPOLLREAD and XPOLLWRITE.
+ */
 int xpoll(struct xpollfd *xfds, int nfds, int timeout);
 
 #endif /* _XPOLL_H */

--- a/src/common/xstring.c
+++ b/src/common/xstring.c
@@ -5,20 +5,20 @@
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Jim Garlick <garlick@llnl.gov>.
  *  UCRL-CODE-2003-005.
- *  
+ *
  *  This file is part of Pdsh, a parallel remote shell program.
  *  For details, see <http://www.llnl.gov/linux/pdsh/>.
- *  
+ *
  *  Pdsh is free software; you can redistribute it and/or modify it under
  *  the terms of the GNU General Public License as published by the Free
  *  Software Foundation; either version 2 of the License, or (at your option)
  *  any later version.
- *  
+ *
  *  Pdsh is distributed in the hope that it will be useful, but WITHOUT ANY
  *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
  *  details.
- *  
+ *
  *  You should have received a copy of the GNU General Public License along
  *  with Pdsh; if not, write to the Free Software Foundation, Inc.,
  *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
@@ -101,7 +101,7 @@ static void _makespace(char **str, int needed)
     }
 }
 
-/* 
+/*
  * Concatenate str2 onto str1, expanding str1 as needed.
  *   str1 (IN/OUT)	target string (pointer to in case of expansion)
  *   str2 (IN)		source string
@@ -112,7 +112,7 @@ void xstrcat(char **str1, char *str2)
     strcat(*str1, str2);
 }
 
-/* 
+/*
  * Copy str2 to str1, expanding str1 as needed.
  *   str1 (IN/OUT)	target string (pointer to in case of expansion)
  *   str2 (IN)		source string
@@ -131,7 +131,7 @@ static void _strcatchar(char *str, char c)
     str[len] = '\0';
 }
 
-/* 
+/*
  * Add a character to str, expanding str1 as needed.
  *   str1 (IN/OUT)	target string (pointer to in case of expansion)
  *   size (IN/OUT)	size of str1 (pointer to in case of expansion)
@@ -168,7 +168,7 @@ void xstrerrorcat(char **buf)
 }
 
 
-/* 
+/*
  * Replacement for libc basename
  *   path (IN)		path possibly containing '/' characters
  *   RETURN		last component of path

--- a/src/common/xstring.h
+++ b/src/common/xstring.h
@@ -5,20 +5,20 @@
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Jim Garlick <garlick@llnl.gov>.
  *  UCRL-CODE-2003-005.
- *  
+ *
  *  This file is part of Pdsh, a parallel remote shell program.
  *  For details, see <http://www.llnl.gov/linux/pdsh/>.
- *  
+ *
  *  Pdsh is free software; you can redistribute it and/or modify it under
  *  the terms of the GNU General Public License as published by the Free
  *  Software Foundation; either version 2 of the License, or (at your option)
  *  any later version.
- *  
+ *
  *  Pdsh is distributed in the hope that it will be useful, but WITHOUT ANY
  *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
  *  details.
- *  
+ *
  *  You should have received a copy of the GNU General Public License along
  *  with Pdsh; if not, write to the Free Software Foundation, Inc.,
  *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.

--- a/src/modules/dshgroup.c
+++ b/src/modules/dshgroup.c
@@ -5,20 +5,20 @@
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Mark Grondona <mgrondona@llnl.gov>
  *  UCRL-CODE-2003-005.
- *  
+ *
  *  This file is part of Pdsh, a parallel remote shell program.
  *  For details, see <http://www.llnl.gov/linux/pdsh/>.
- *  
+ *
  *  Pdsh is free software; you can redistribute it and/or modify it under
  *  the terms of the GNU General Public License as published by the Free
  *  Software Foundation; either version 2 of the License, or (at your option)
  *  any later version.
- *  
+ *
  *  Pdsh is distributed in the hope that it will be useful, but WITHOUT ANY
  *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
  *  details.
- *  
+ *
  *  You should have received a copy of the GNU General Public License along
  *  with Pdsh; if not, write to the Free Software Foundation, Inc.,
  *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
@@ -47,7 +47,7 @@
 #if STATIC_MODULES
 #  define pdsh_module_info dshgroup_module_info
 #  define pdsh_module_priority dshgroup_module_priority
-#endif    
+#endif
 
 int pdsh_module_priority = DEFAULT_MODULE_PRIORITY;
 
@@ -58,17 +58,17 @@ static int dshgroup_process_opt(opt_t *, int, char *);
 static List groups = NULL;
 static List exgroups = NULL;
 
-/* 
+/*
  * Export pdsh module operations structure
  */
 struct pdsh_module_operations dshgroup_module_ops = {
-    (ModInitF)       NULL, 
-    (ModExitF)       NULL, 
-    (ModReadWcollF)  read_groupfile, 
+    (ModInitF)       NULL,
+    (ModExitF)       NULL,
+    (ModReadWcollF)  read_groupfile,
     (ModPostOpF)     dshgroup_postop,
 };
 
-/* 
+/*
  * Export rcmd module operations
  */
 struct pdsh_rcmd_operations dshgroup_rcmd_ops = {
@@ -77,26 +77,26 @@ struct pdsh_rcmd_operations dshgroup_rcmd_ops = {
     (RcmdF)      NULL,
 };
 
-/* 
+/*
  * Export module options
  */
-struct pdsh_module_option dshgroup_module_options[] = 
- { { 'g', "groupname", "target hosts in dsh group \"groupname\"", 
+struct pdsh_module_option dshgroup_module_options[] =
+ { { 'g', "groupname", "target hosts in dsh group \"groupname\"",
    DSH | PCP, (optFunc) dshgroup_process_opt },
-   { 'X', "groupname", "exclude hosts in dsh group \"groupname\"", 
+   { 'X', "groupname", "exclude hosts in dsh group \"groupname\"",
    DSH | PCP, (optFunc) dshgroup_process_opt },
    PDSH_OPT_TABLE_END
  };
 
-/* 
- * Machines module info 
+/*
+ * Machines module info
  */
 struct pdsh_module pdsh_module_info = {
   "misc",
   "dshgroup",
   "Mark Grondona <mgrondona@llnl.gov>",
   "Read list of targets from dsh-style \"group\" files",
-  DSH | PCP, 
+  DSH | PCP,
   &dshgroup_module_ops,
   &dshgroup_rcmd_ops,
   &dshgroup_module_options[0],
@@ -159,7 +159,7 @@ static hostlist_t _read_groups (List grouplist)
 
         if (l == NULL)
             continue;
-    
+
         if (hl == NULL) {
             hl = l;
         } else {
@@ -205,7 +205,7 @@ _delete_all (hostlist_t hl, hostlist_t dl)
 static int dshgroup_postop (opt_t *opt)
 {
     hostlist_t hl = NULL;
-    
+
     if (!opt->wcoll || !exgroups)
         return (0);
 

--- a/src/modules/execcmd.c
+++ b/src/modules/execcmd.c
@@ -5,37 +5,37 @@
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Jim Garlick <garlick@llnl.gov>.
  *  UCRL-CODE-2003-005.
- *  
+ *
  *  This file is part of Pdsh, a parallel remote shell program.
  *  For details, see <http://www.llnl.gov/linux/pdsh/>.
- *  
+ *
  *  Pdsh is free software; you can redistribute it and/or modify it under
  *  the terms of the GNU General Public License as published by the Free
  *  Software Foundation; either version 2 of the License, or (at your option)
  *  any later version.
- *  
+ *
  *  Pdsh is distributed in the hope that it will be useful, but WITHOUT ANY
  *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
  *  details.
- *  
+ *
  *  You should have received a copy of the GNU General Public License along
  *  with Pdsh; if not, write to the Free Software Foundation, Inc.,
  *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
 \*****************************************************************************/
 
 /*
- *  This module uses the "pipecmd" interface to execute 
+ *  This module uses the "pipecmd" interface to execute
  *   arbitrary processes. First of the "remote" args is the
- *   command to execute. Some simple parameters are substituted 
+ *   command to execute. Some simple parameters are substituted
  *   on the command line:
- * 
+ *
  *    %h :  Target "hostname"
  *    %u :  Remote username
  *    %n :  Remote "rank" (0-n)
  *
  *  E.g.:
- *   
+ *
  *   pdsh -Rexec -w foo[0-1] ssh -l %u -x %h hostname
  *
  *  would somewhat mimic the existing ssh module.
@@ -60,7 +60,7 @@
 #if STATIC_MODULES
 #  define pdsh_module_info execcmd_module_info
 #  define pdsh_module_priority execcmd_module_priority
-#endif    
+#endif
 
 int pdsh_module_priority = DEFAULT_MODULE_PRIORITY;
 
@@ -69,7 +69,7 @@ static int mod_exec_exit (void);
 
 static int exec_init(opt_t *);
 static int exec_signal(int, void *arg, int);
-static int execcmd(char *, char *, char *, char *, char *, int, int *, void **); 
+static int execcmd(char *, char *, char *, char *, char *, int, int *, void **);
 static int exec_destroy (pipecmd_t p);
 
 /*
@@ -92,16 +92,16 @@ struct pdsh_rcmd_operations execcmd_rcmd_ops = {
     (RcmdDestroyF) exec_destroy
 };
 
-/* 
+/*
  * Export module options
  */
-struct pdsh_module_option execcmd_module_options[] = 
- { 
+struct pdsh_module_option execcmd_module_options[] =
+ {
    PDSH_OPT_TABLE_END
  };
 
-/* 
- * Sshcmd module info 
+/*
+ * Sshcmd module info
  */
 struct pdsh_module pdsh_module_info = {
   "rcmd",
@@ -181,7 +181,7 @@ execcmd(char *ahost, char *addr, char *luser, char *ruser, char *cmd,
     return (pipecmd_stdoutfd (p));
 }
 
-static int 
+static int
 exec_destroy (pipecmd_t p)
 {
     int status;

--- a/src/modules/genders.c
+++ b/src/modules/genders.c
@@ -5,20 +5,20 @@
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Jim Garlick <garlick@llnl.gov>.
  *  UCRL-CODE-2003-005.
- *  
+ *
  *  This file is part of Pdsh, a parallel remote shell program.
  *  For details, see <http://www.llnl.gov/linux/pdsh/>.
- *  
+ *
  *  Pdsh is free software; you can redistribute it and/or modify it under
  *  the terms of the GNU General Public License as published by the Free
  *  Software Foundation; either version 2 of the License, or (at your option)
  *  any later version.
- *  
+ *
  *  Pdsh is distributed in the hope that it will be useful, but WITHOUT ANY
  *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
  *  details.
- *  
+ *
  *  You should have received a copy of the GNU General Public License along
  *  with Pdsh; if not, write to the Free Software Foundation, Inc.,
  *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
@@ -50,7 +50,7 @@
 #if STATIC_MODULES
 #  define pdsh_module_info genders_module_info
 #  define pdsh_module_priority genders_module_priority
-#endif    
+#endif
 
 int pdsh_module_priority = DEFAULT_MODULE_PRIORITY;
 
@@ -78,17 +78,17 @@ static char *gfile     = NULL;
 static List attrlist   = NULL;
 static List excllist   = NULL;
 
-/* 
+/*
  * Export pdsh module operations structure
  */
 struct pdsh_module_operations genders_module_ops = {
-    (ModInitF)       genders_init, 
-    (ModExitF)       genders_fini, 
-    (ModReadWcollF)  genders_wcoll, 
+    (ModInitF)       genders_init,
+    (ModExitF)       genders_fini,
+    (ModReadWcollF)  genders_wcoll,
     (ModPostOpF)     genders_postop,
 };
 
-/* 
+/*
  * Export rcmd module operations
  */
 struct pdsh_rcmd_operations genders_rcmd_ops = {
@@ -97,16 +97,16 @@ struct pdsh_rcmd_operations genders_rcmd_ops = {
     (RcmdF)      NULL,
 };
 
-/* 
+/*
  * Export module options
  */
-struct pdsh_module_option genders_module_options[] = 
- { 
-   { 'g', "query,...", 
+struct pdsh_module_option genders_module_options[] =
+ {
+   { 'g', "query,...",
      "target nodes using genders query",
-     DSH | PCP, (optFunc) genders_process_opt 
+     DSH | PCP, (optFunc) genders_process_opt
    },
-   { 'X', "query,...", 
+   { 'X', "query,...",
      "exclude nodes using genders query",
      DSH | PCP, (optFunc) genders_process_opt
    },
@@ -117,8 +117,8 @@ struct pdsh_module_option genders_module_options[] =
    { 'i', NULL, "request alternate or canonical hostnames if applicable",
      DSH | PCP, (optFunc) genders_process_opt
    },
-   { 'a', NULL, "target all nodes except those with \"pdsh_all_skip\" attribute", 
-     DSH | PCP, (optFunc) genders_process_opt 
+   { 'a', NULL, "target all nodes except those with \"pdsh_all_skip\" attribute",
+     DSH | PCP, (optFunc) genders_process_opt
    },
    { 'A', NULL, "target all nodes listed in genders database",
      DSH | PCP, (optFunc) genders_process_opt
@@ -127,8 +127,8 @@ struct pdsh_module_option genders_module_options[] =
    PDSH_OPT_TABLE_END
  };
 
-/* 
- * Genders module info 
+/*
+ * Genders module info
  */
 struct pdsh_module pdsh_module_info = {
     "misc",
@@ -139,7 +139,7 @@ struct pdsh_module pdsh_module_info = {
 #endif /* GENDERS_G_ONLY */
     "Jim Garlick <garlick@llnl.gov>",
     "target nodes using libgenders and genders attributes",
-    DSH | PCP, 
+    DSH | PCP,
 
     &genders_module_ops,
     &genders_rcmd_ops,
@@ -166,8 +166,8 @@ genders_process_opt(opt_t *pdsh_opts, int opt, char *arg)
 {
     switch (opt) {
 #if !GENDERS_G_ONLY
-    case 'a':  
-        /* For -a, exclude nodes with "pdsh_all_skip" */ 
+    case 'a':
+        /* For -a, exclude nodes with "pdsh_all_skip" */
         excllist = list_split_append (excllist, ",", "pdsh_all_skip");
     case 'A':
         allnodes = true;
@@ -215,7 +215,7 @@ genders_fini(void)
     return 0;
 }
 
-static hostlist_t 
+static hostlist_t
 genders_wcoll(opt_t *opt)
 {
     _genders_opt_verify(opt);
@@ -346,7 +346,7 @@ genders_postop(opt_t *opt)
 }
 
 
-/* 
+/*
  * Verify options passed to this module
  */
 static void
@@ -406,7 +406,7 @@ _genders_to_altnames(genders_t g, hostlist_t hl)
          *  If node not found, attempt to lookup canonical name via
          *   altername name.
          */
-        if ((rc < 0) && (genders_errnum(g) == GENDERS_ERR_NOTFOUND)) 
+        if ((rc < 0) && (genders_errnum(g) == GENDERS_ERR_NOTFOUND))
             rc = genders_getnodes (g, &altname, 1, altattr, host);
 
         if (hostlist_push_host(retlist, (rc > 0 ? altname : host)) <= 0)
@@ -422,7 +422,7 @@ _genders_to_altnames(genders_t g, hostlist_t hl)
     return (retlist);
 }
 
-static hostlist_t 
+static hostlist_t
 _genders_to_hostlist(genders_t gh, char **nodes, int nnodes)
 {
     hostlist_t hl = NULL;
@@ -515,7 +515,7 @@ _get_val(char *attr)
 }
 #endif /* !HAVE_GENDERS_QUERY */
 
-static hostlist_t 
+static hostlist_t
 _read_genders_attr(char *query)
 {
     hostlist_t hl = NULL;
@@ -527,7 +527,7 @@ _read_genders_attr(char *query)
 
 #if HAVE_GENDERS_QUERY
     if ((nnodes = genders_query (gh, nodes, len, query)) < 0) {
-        errx("%p: Error querying genders for query \"%s\": %s\n", 
+        errx("%p: Error querying genders for query \"%s\": %s\n",
                 query ? query : "(all)", genders_errormsg(gh));
     }
 #else /* !HAVE_GENDERS_QUERY */
@@ -536,7 +536,7 @@ _read_genders_attr(char *query)
         char *val;
         val = _get_val(query);
         if ((nnodes = genders_getnodes(gh, nodes, len, query, val)) < 0) {
-            errx("%p: Error querying genders for attr \"%s\": %s\n", 
+            errx("%p: Error querying genders for attr \"%s\": %s\n",
                  query ? query : "(all)", genders_errormsg(gh));
         }
     }
@@ -552,7 +552,7 @@ _read_genders_attr(char *query)
     return hl;
 }
 
-static hostlist_t 
+static hostlist_t
 _read_genders (List attrs)
 {
     hostlist_t   hl = NULL;
@@ -581,10 +581,10 @@ _read_genders (List attrs)
     return (hl);
 }
 
-static int 
+static int
 attrval_by_altname (genders_t g, const char *host, const char *attr,
                            char *val, int len)
-{   
+{
     char *altname = NULL;
     char *altattr = GENDERS_ALTNAME_ATTRIBUTE;
     int maxlen = _maxnamelen (g);
@@ -605,8 +605,8 @@ attrval_by_altname (genders_t g, const char *host, const char *attr,
  *  Parse the value of "pdsh_rcmd_type" and split into user and rcmd
  *   strings, passing rcmd name (if any) in *rp, and user name (if any)
  *   in *up.
- *   
- *  Allows pdsh_rcmd_type to be set to [user@][rcmd], where user@ and 
+ *
+ *  Allows pdsh_rcmd_type to be set to [user@][rcmd], where user@ and
  *   rcmd are both optional. (i.e. you can set user or rcmd or both)
  */
 static int rcmd_type_parse (char *val, char **rp, char **up)
@@ -636,10 +636,10 @@ register_genders_rcmd_types (opt_t *opt)
     char rcmd_attr[] = "pdsh_rcmd_type";
     hostlist_iterator_t i = NULL;
 
-    if (!opt->wcoll) 
+    if (!opt->wcoll)
         return (0);
 
-    /* 
+    /*
      *  Assume no nodes have "pdsh_rcmd_type" attr if index fails:
      */
     if (genders_index_attrvals (gh, rcmd_attr) < 0)
@@ -655,23 +655,23 @@ register_genders_rcmd_types (opt_t *opt)
          *  If host wasn't found, try to see if "host" is the altname
          *   for this node, then lookup with the real name
          */
-        if (rc < 0 && (genders_errnum(gh) == GENDERS_ERR_NOTFOUND)) 
+        if (rc < 0 && (genders_errnum(gh) == GENDERS_ERR_NOTFOUND))
             rc = attrval_by_altname (gh, host, rcmd_attr, val, sizeof (val));
-        
+
         rcmd_type_parse (val, &rcmd, &user);
 
-        if (rc > 0) 
+        if (rc > 0)
             rcmd_register_defaults (host, rcmd, user);
 
         free (host);
     }
 
     hostlist_iterator_destroy (i);
-            
+
     return 0;
 }
 
-static int 
+static int
 _delete_all (hostlist_t hl, hostlist_t dl)
 {
     int                 rc   = 0;

--- a/src/modules/k4cmd.c
+++ b/src/modules/k4cmd.c
@@ -5,27 +5,27 @@
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Jim Garlick <garlick@llnl.gov>.
  *  UCRL-CODE-2003-005.
- *  
+ *
  *  This file is part of Pdsh, a parallel remote shell program.
  *  For details, see <http://www.llnl.gov/linux/pdsh/>.
- *  
+ *
  *  Pdsh is free software; you can redistribute it and/or modify it under
  *  the terms of the GNU General Public License as published by the Free
  *  Software Foundation; either version 2 of the License, or (at your option)
  *  any later version.
- *  
+ *
  *  Pdsh is distributed in the hope that it will be useful, but WITHOUT ANY
  *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
  *  details.
- *  
+ *
  *  You should have received a copy of the GNU General Public License along
  *  with Pdsh; if not, write to the Free Software Foundation, Inc.,
  *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
 \*****************************************************************************/
 
 /*
- * This code is based on the MIT Kerberos IV kcmd.c with some athena hacks 
+ * This code is based on the MIT Kerberos IV kcmd.c with some athena hacks
  * removed and MT safety added, and the interface changed.  Original UC regents
  * header from BSD included below.
  *
@@ -35,7 +35,7 @@
 
 /*
  * Copyright (c) 1983 Regents of the University of California. All rights
- * reserved. 
+ * reserved.
  *
  * Redistribution and use in source and binary forms are permitted provided that
  * the above copyright notice and this paragraph are duplicated in all such
@@ -46,7 +46,7 @@
  * derived from this software without specific prior written permission. THIS
  * SOFTWARE IS PROVIDED ``AS IS'' AND WITHOUT ANY EXPRESS OR IMPLIED
  * WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF
- * MERCHANTIBILITY AND FITNESS FOR A PARTICULAR PURPOSE. 
+ * MERCHANTIBILITY AND FITNESS FOR A PARTICULAR PURPOSE.
  */
 
 #if     HAVE_CONFIG_H
@@ -95,7 +95,7 @@
 #if STATIC_MODULES
 #  define pdsh_module_info k4cmd_module_info
 #  define pdsh_module_priority k4cmd_module_priority
-#endif    
+#endif
 
 int pdsh_module_priority = DEFAULT_MODULE_PRIORITY;
 
@@ -104,15 +104,15 @@ extern char *inet_ntoa();
 
 static int k4cmd_init(opt_t *);
 static int k4cmd_signal(int, void *, int);
-static int k4cmd(char *, char *, char *, char *, char *, int, int *, void **); 
+static int k4cmd(char *, char *, char *, char *, char *, int, int *, void **);
 
-/* 
+/*
  * Export pdsh module operations structure
  */
 struct pdsh_module_operations k4cmd_module_ops = {
-    (ModInitF)       NULL, 
-    (ModExitF)       NULL, 
-    (ModReadWcollF)  NULL, 
+    (ModInitF)       NULL,
+    (ModExitF)       NULL,
+    (ModReadWcollF)  NULL,
     (ModPostOpF)     NULL,
 };
 
@@ -125,23 +125,23 @@ struct pdsh_rcmd_operations k4cmd_rcmd_ops = {
     (RcmdF)      k4cmd,
 };
 
-/* 
+/*
  * Export module options
  */
-struct pdsh_module_option k4cmd_module_options[] = 
- { 
+struct pdsh_module_option k4cmd_module_options[] =
+ {
    PDSH_OPT_TABLE_END
  };
 
-/* 
- * k4cmd module info 
+/*
+ * k4cmd module info
  */
 struct pdsh_module pdsh_module_info = {
     "rcmd",
     "k4",
     "Jim Garlick <garlick@llnl.gov>",
     "kerberos based rcmd connect method",
-    DSH | PCP, 
+    DSH | PCP,
 
     &k4cmd_module_ops,
     &k4cmd_rcmd_ops,
@@ -286,7 +286,7 @@ k4cmd(char *ahost, char *addr, char *locuser, char *remuser, char *cmd,
 
     /*
      * Kerberos-authenticated service.  Don't have to send locuser, since
-     * its already in the ticket, and we'll extract it on the other side. 
+     * its already in the ticket, and we'll extract it on the other side.
      */
     /*krb_options |= KOPT_DONT_CANON; */
     pthread_mutex_lock(&mylock);
@@ -301,7 +301,7 @@ k4cmd(char *ahost, char *addr, char *locuser, char *remuser, char *cmd,
          * bits. This only catches the case of total failure -- but
          * that's the one where we get useful data from the remote
          * end. If we even get an authenticator back, then the
-         * problem gets diagnosed locally anyhow. 
+         * problem gets diagnosed locally anyhow.
          */
         extern KRB_INT32 __krb_sendauth_hidden_tkt_len;
         char *old_data = (char *) &__krb_sendauth_hidden_tkt_len;

--- a/src/modules/machines.c
+++ b/src/modules/machines.c
@@ -5,20 +5,20 @@
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Jim Garlick <garlick@llnl.gov>.
  *  UCRL-CODE-2003-005.
- *  
+ *
  *  This file is part of Pdsh, a parallel remote shell program.
  *  For details, see <http://www.llnl.gov/linux/pdsh/>.
- *  
+ *
  *  Pdsh is free software; you can redistribute it and/or modify it under
  *  the terms of the GNU General Public License as published by the Free
  *  Software Foundation; either version 2 of the License, or (at your option)
  *  any later version.
- *  
+ *
  *  Pdsh is distributed in the hope that it will be useful, but WITHOUT ANY
  *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
  *  details.
- *  
+ *
  *  You should have received a copy of the GNU General Public License along
  *  with Pdsh; if not, write to the Free Software Foundation, Inc.,
  *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
@@ -36,7 +36,7 @@
 #if STATIC_MODULES
 #  define pdsh_module_info machines_module_info
 #  define pdsh_module_priority machines_module_priority
-#endif    
+#endif
 
 int pdsh_module_priority = DEFAULT_MODULE_PRIORITY;
 
@@ -45,17 +45,17 @@ static int machines_opt_a(opt_t *, int, char *);
 
 static bool allnodes = false;
 
-/* 
+/*
  * Export pdsh module operations structure
  */
 struct pdsh_module_operations machines_module_ops = {
-    (ModInitF)       NULL, 
-    (ModExitF)       NULL, 
-    (ModReadWcollF)  read_machines, 
+    (ModInitF)       NULL,
+    (ModExitF)       NULL,
+    (ModReadWcollF)  read_machines,
     (ModPostOpF)     NULL,
 };
 
-/* 
+/*
  * Export rcmd module operations
  */
 struct pdsh_rcmd_operations machines_rcmd_ops = {
@@ -64,23 +64,23 @@ struct pdsh_rcmd_operations machines_rcmd_ops = {
     (RcmdF)      NULL,
 };
 
-/* 
+/*
  * Export module options
  */
-struct pdsh_module_option machines_module_options[] = 
+struct pdsh_module_option machines_module_options[] =
  { { 'a', NULL, "target all nodes", DSH | PCP, (optFunc) machines_opt_a },
    PDSH_OPT_TABLE_END
  };
 
-/* 
- * Machines module info 
+/*
+ * Machines module info
  */
 struct pdsh_module pdsh_module_info = {
   "misc",
   "machines",
   "Jim Garlick <garlick@llnl.gov>",
   "Read list of all nodes from a machines file",
-  DSH | PCP, 
+  DSH | PCP,
 
   &machines_module_ops,
   &machines_rcmd_ops,

--- a/src/modules/mcmd.c
+++ b/src/modules/mcmd.c
@@ -5,20 +5,20 @@
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Jim Garlick <garlick@llnl.gov>.
  *  UCRL-CODE-2003-005.
- *  
+ *
  *  This file is part of Pdsh, a parallel remote shell program.
  *  For details, see <http://www.llnl.gov/linux/pdsh/>.
- *  
+ *
  *  Pdsh is free software; you can redistribute it and/or modify it under
  *  the terms of the GNU General Public License as published by the Free
  *  Software Foundation; either version 2 of the License, or (at your option)
  *  any later version.
- *  
+ *
  *  Pdsh is distributed in the hope that it will be useful, but WITHOUT ANY
  *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
  *  details.
- *  
+ *
  *  You should have received a copy of the GNU General Public License along
  *  with Pdsh; if not, write to the Free Software Foundation, Inc.,
  *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
@@ -26,7 +26,7 @@
 
 /*
  * Started with BSD mcmd.c which is:
- * 
+ *
  * Copyright (c) 1983, 1993, 1994, 2003
  *      The Regents of the University of California.  All rights reserved.
  *
@@ -53,12 +53,12 @@
  *    under the terms of the GNU General Public License as published
  *    by the Free Software Foundation; either version 2 of the
  *    License, or (at your option) any later version.
- *                              
+ *
  * 6. This is distributed in the hope that it will be useful, but
  *    WITHOUT ANY WARRANTY; without even the implied warranty of
  *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *    GNU General Public License for more details.
- *                                                           
+ *
  * 7. You should have received a copy of the GNU General Public License;
  *    if not, write to the Free Software Foundation, Inc., 59 Temple
  *    Place, Suite 330, Boston, MA  02111-1307  USA.
@@ -146,24 +146,24 @@ static char sccsid[] = "@(#)mcmd.c      Based from: 8.3 (Berkeley) 3/26/94";
 #if STATIC_MODULES
 #  define pdsh_module_info mcmd_module_info
 #  define pdsh_module_priority mcmd_module_priority
-#endif    
+#endif
 
 int pdsh_module_priority = DEFAULT_MODULE_PRIORITY;
 
 static int mcmd_init(opt_t *);
 static int mcmd_signal(int, void *, int);
-static int mcmd(char *, char *, char *, char *, char *, int, int *, void **); 
+static int mcmd(char *, char *, char *, char *, char *, int, int *, void **);
 
 /* random num for all jobs in this group */
 static unsigned int randy = -1;
 
-/* 
+/*
  * Export pdsh module operations structure
  */
 struct pdsh_module_operations mcmd_module_ops = {
-    (ModInitF)       NULL, 
-    (ModExitF)       NULL, 
-    (ModReadWcollF)  NULL, 
+    (ModInitF)       NULL,
+    (ModExitF)       NULL,
+    (ModReadWcollF)  NULL,
     (ModPostOpF)     NULL,
 };
 
@@ -176,23 +176,23 @@ struct pdsh_rcmd_operations mcmd_rcmd_ops = {
     (RcmdF)        mcmd,
 };
 
-/* 
+/*
  * Export module options
  */
-struct pdsh_module_option mcmd_module_options[] = 
-{ 
+struct pdsh_module_option mcmd_module_options[] =
+{
     PDSH_OPT_TABLE_END
 };
 
-/* 
- * Mcmd module info 
+/*
+ * Mcmd module info
  */
 struct pdsh_module pdsh_module_info = {
     "rcmd",
     "mrsh",
     "Al Chu <chu11@llnl.gov>",
     "mrsh rcmd connect method",
-    DSH | PCP, 
+    DSH | PCP,
 
     &mcmd_module_ops,
     &mcmd_rcmd_ops,
@@ -211,7 +211,7 @@ mcmd_init(opt_t * opt)
         setuid (getuid ());
 
     /*
-     * Generate a random number to send in our package to the 
+     * Generate a random number to send in our package to the
      * server.  We will see it again and compare it when the
      * server sets up the stderr socket and sends it to us.
      * We need to loop for the tiny possibility we read 0 :P
@@ -292,7 +292,7 @@ encode_localhost_string (const char *host, char *str, int maxlen)
  *      locuser (IN)            local username
  *      remuser (IN)            remote username
  *      cmd (IN)                remote command to execute under shell
- *      rank (IN)               not used 
+ *      rank (IN)               not used
  *      fd2p (IN)               if non NULL, return stderr file descriptor here
  *      int (RETURN)            -1 on error, socket for I/O on success
  *
@@ -301,10 +301,10 @@ encode_localhost_string (const char *host, char *str, int maxlen)
  * - using "err" function output errors.
  * - passing in address as addr intead of calling gethostbyname
  * - using default mshell port instead of calling getservbyname
- * 
+ *
  */
-static int 
-mcmd(char *ahost, char *addr, char *locuser, char *remuser, char *cmd, 
+static int
+mcmd(char *ahost, char *addr, char *locuser, char *remuser, char *cmd,
         int rank, int *fd2p, void **argp)
 {
     struct sockaddr m_socket;
@@ -365,7 +365,7 @@ mcmd(char *ahost, char *addr, char *locuser, char *remuser, char *cmd,
 
     sin.sin_family = AF_INET;
 
-    memcpy(&sin.sin_addr.s_addr, addr, IP_ADDR_LEN); 
+    memcpy(&sin.sin_addr.s_addr, addr, IP_ADDR_LEN);
 
     sin.sin_port = htons(MRSH_PORT);
     if (connect(s, (struct sockaddr *)&sin, sizeof(sin)) < 0) {
@@ -423,12 +423,12 @@ mcmd(char *ahost, char *addr, char *locuser, char *remuser, char *cmd,
     /* put port in buffer. will be 0 if user didn't want stderr */
     snprintf(num,sizeof(num),"%d",lport);
 
-    /* 
+    /*
      * Use special keyed string if target is localhost, otherwise,
      *  encode the IP addr string.
      */
     if (!encode_localhost_string (ahost, haddrdot, sizeof (haddrdot))) {
-        /* inet_ntoa is not thread safe, so we use the following, 
+        /* inet_ntoa is not thread safe, so we use the following,
          * which is more or less ripped from glibc
          */
         memcpy(&m_in.s_addr, addr, IP_ADDR_LEN);
@@ -440,8 +440,8 @@ mcmd(char *ahost, char *addr, char *locuser, char *remuser, char *cmd,
      * We call munge_encode which will take what we write in and return a
      * pointer to an munged buffer.  What we get back is a null terminated
      * string of encrypted characters.
-     * 
-     * The format of the unmunged buffer is as follows (each a string terminated 
+     *
+     * The format of the unmunged buffer is as follows (each a string terminated
      * with a '\0' (null):
      *
      * stderr_port_number & /dev/urandom_client_produce_number are 0
@@ -461,15 +461,15 @@ mcmd(char *ahost, char *addr, char *locuser, char *remuser, char *cmd,
      * users_command                              variable        "ls -al"
      * '\0' '\0'
      *
-     * (The last extra null is accounted for in the following line's 
+     * (The last extra null is accounted for in the following line's
      *  last strlen() call.)
      *
      */
 
     mpvers = MRSH_PROTOCOL_VERSION;
 
-    mcount = ((strlen(remuser)+1) + (strlen(mpvers)+1) + 
-              (strlen(haddrdot)+1) + (strlen(num)+1) + 
+    mcount = ((strlen(remuser)+1) + (strlen(mpvers)+1) +
+              (strlen(haddrdot)+1) + (strlen(num)+1) +
               (strlen(num_seq)+1) + strlen(cmd)+2);
 
     tmbuf = mbuf = malloc(mcount);
@@ -502,7 +502,7 @@ mcmd(char *ahost, char *addr, char *locuser, char *remuser, char *cmd,
     if ((rv = munge_encode(&m,ctx,mbuf,mcount)) != EMUNGE_SUCCESS) {
         err("%p: %S: mcmd: munge_encode: %s\n", ahost, munge_ctx_strerror(ctx));
         munge_ctx_destroy(ctx);
-        if (s2 >= 0) 
+        if (s2 >= 0)
             close(s2);
         free(tmbuf);
         goto bad;
@@ -514,7 +514,7 @@ mcmd(char *ahost, char *addr, char *locuser, char *remuser, char *cmd,
 
     /*
      * Write stderr port in the clear in case we can't decode for
-     * some reason (i.e. bad credentials).  May be 0 if user 
+     * some reason (i.e. bad credentials).  May be 0 if user
      * doesn't want stderr
      */
     if (fd2p != NULL) {
@@ -565,8 +565,8 @@ mcmd(char *ahost, char *addr, char *locuser, char *remuser, char *cmd,
         xpfds[0].fd = s;
         xpfds[1].fd = s2;
         xpfds[0].events = xpfds[1].events = XPOLLREAD;
-        if (  ((rv = xpoll(xpfds, 2, -1)) < 0) 
-            || rv != 1 
+        if (  ((rv = xpoll(xpfds, 2, -1)) < 0)
+            || rv != 1
             || (xpfds[0].revents > 0)) {
             if (errno != 0)
                 err("%p: %S: mcmd: xpoll (setting up stderr): %m\n", ahost);

--- a/src/modules/netgroup.c
+++ b/src/modules/netgroup.c
@@ -5,20 +5,20 @@
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Mark Grondona <mgrondona@llnl.gov>
  *  UCRL-CODE-2003-005.
- *  
+ *
  *  This file is part of Pdsh, a parallel remote shell program.
  *  For details, see <http://www.llnl.gov/linux/pdsh/>.
- *  
+ *
  *  Pdsh is free software; you can redistribute it and/or modify it under
  *  the terms of the GNU General Public License as published by the Free
  *  Software Foundation; either version 2 of the License, or (at your option)
  *  any later version.
- *  
+ *
  *  Pdsh is distributed in the hope that it will be useful, but WITHOUT ANY
  *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
  *  details.
- *  
+ *
  *  You should have received a copy of the GNU General Public License along
  *  with Pdsh; if not, write to the Free Software Foundation, Inc.,
  *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
@@ -43,7 +43,7 @@
 #if STATIC_MODULES
 #  define pdsh_module_info netgroup_module_info
 #  define pdsh_module_priority netgroup_module_priority
-#endif    
+#endif
 
 int pdsh_module_priority = DEFAULT_MODULE_PRIORITY;
 
@@ -54,17 +54,17 @@ static int netgroup_process_opt(opt_t *, int, char *);
 static List groups = NULL;
 static List exgroups = NULL;
 
-/* 
+/*
  * Export pdsh module operations structure
  */
 struct pdsh_module_operations netgroup_module_ops = {
-    (ModInitF)       NULL, 
-    (ModExitF)       NULL, 
-    (ModReadWcollF)  read_netgroup, 
+    (ModInitF)       NULL,
+    (ModExitF)       NULL,
+    (ModReadWcollF)  read_netgroup,
     (ModPostOpF)     netgroup_postop,
 };
 
-/* 
+/*
  * Export rcmd module operations
  */
 struct pdsh_rcmd_operations netgroup_rcmd_ops = {
@@ -73,26 +73,26 @@ struct pdsh_rcmd_operations netgroup_rcmd_ops = {
     (RcmdF)      NULL,
 };
 
-/* 
+/*
  * Export module options
  */
-struct pdsh_module_option netgroup_module_options[] = 
- { { 'g', "groupname", "target hosts in netgroup \"groupname\"", 
+struct pdsh_module_option netgroup_module_options[] =
+ { { 'g', "groupname", "target hosts in netgroup \"groupname\"",
    DSH | PCP, (optFunc) netgroup_process_opt },
-   { 'X', "groupname", "exclude hosts in netgroup \"groupname\"", 
+   { 'X', "groupname", "exclude hosts in netgroup \"groupname\"",
    DSH | PCP, (optFunc) netgroup_process_opt },
    PDSH_OPT_TABLE_END
  };
 
 /*
- * Machines module info 
+ * Machines module info
  */
 struct pdsh_module pdsh_module_info = {
   "misc",
   "netgroup",
   "Mark Grondona <mgrondona@llnl.gov>",
   "Target netgroups from pdsh",
-  DSH | PCP, 
+  DSH | PCP,
   &netgroup_module_ops,
   &netgroup_rcmd_ops,
   &netgroup_module_options[0],
@@ -148,7 +148,7 @@ static hostlist_t _read_groups (List grouplist)
 
         if (l == NULL)
             continue;
-    
+
         if (hl == NULL) {
             hl = l;
         } else {
@@ -194,7 +194,7 @@ _delete_all (hostlist_t hl, hostlist_t dl)
 static int netgroup_postop (opt_t *opt)
 {
     hostlist_t hl = NULL;
-    
+
     if (!opt->wcoll || !exgroups)
         return (0);
 

--- a/src/modules/nodeupdown.c
+++ b/src/modules/nodeupdown.c
@@ -5,20 +5,20 @@
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Jim Garlick <garlick@llnl.gov>.
  *  UCRL-CODE-2003-005.
- *  
+ *
  *  This file is part of Pdsh, a parallel remote shell program.
  *  For details, see <http://www.llnl.gov/linux/pdsh/>.
- *  
+ *
  *  Pdsh is free software; you can redistribute it and/or modify it under
  *  the terms of the GNU General Public License as published by the Free
  *  Software Foundation; either version 2 of the License, or (at your option)
  *  any later version.
- *  
+ *
  *  Pdsh is distributed in the hope that it will be useful, but WITHOUT ANY
  *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
  *  details.
- *  
+ *
  *  You should have received a copy of the GNU General Public License along
  *  with Pdsh; if not, write to the Free Software Foundation, Inc.,
  *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
@@ -43,7 +43,7 @@
 #if STATIC_MODULES
 #  define pdsh_module_info nodeupdown_module_info
 #  define pdsh_module_priority nodeupdown_module_priority
-#endif    
+#endif
 
 int pdsh_module_priority = 120;
 
@@ -53,7 +53,7 @@ static void remove_all_down_nodes(hostlist_t);
 
 static bool verify = false;
 
-/* 
+/*
  * Export pdsh module operations structure
  */
 struct pdsh_module_operations nodeupdown_module_ops = {
@@ -63,7 +63,7 @@ struct pdsh_module_operations nodeupdown_module_ops = {
     (ModPostOpF)     mod_nodeupdown_postop
 };
 
-/* 
+/*
  * Export rcmd module operations
  */
 struct pdsh_rcmd_operations nodeupdown_rcmd_ops = {
@@ -72,25 +72,25 @@ struct pdsh_rcmd_operations nodeupdown_rcmd_ops = {
     (RcmdF)      NULL,
 };
 
-/* 
+/*
  * Export module options
  */
-struct pdsh_module_option nodeupdown_module_options[] = 
- { { 'v', NULL, "exclude targets if they are down", 
+struct pdsh_module_option nodeupdown_module_options[] =
+ { { 'v', NULL, "exclude targets if they are down",
      DSH | PCP, (optFunc) nodeupdown_opt_v
    },
    PDSH_OPT_TABLE_END
  };
 
-/* 
- * Nodeupdown module info 
+/*
+ * Nodeupdown module info
  */
 struct pdsh_module pdsh_module_info = {
   "misc",
   "nodeupdown",
   "Al Chu <chu11@llnl.gov>",
   "remove targets if down according to libnodeupdown",
-  DSH | PCP, 
+  DSH | PCP,
 
   &nodeupdown_module_ops,
   &nodeupdown_rcmd_ops,
@@ -124,14 +124,14 @@ remove_all_down_nodes(hostlist_t wcoll)
     nodeupdown_t  nh   = NULL;
     char *        host = NULL;
     hostlist_iterator_t i = NULL;
-    
+
     if ((nh = nodeupdown_handle_create()) == NULL)
         errx("%p: Unable to create nodeupdown handle.\n");
 
 #if HAVE_NODEUPDOWN_LOAD_DATA_6
-    if (nodeupdown_load_data(nh, NULL, NULL, NULL, 0, 0) < 0) 
+    if (nodeupdown_load_data(nh, NULL, NULL, NULL, 0, 0) < 0)
 #else
-    if (nodeupdown_load_data(nh, NULL, 0, 0, NULL) < 0) 
+    if (nodeupdown_load_data(nh, NULL, 0, 0, NULL) < 0)
 #endif
         errx("%p: nodeupdown: %s\n", nodeupdown_errormsg(nh));
 

--- a/src/modules/slurm.c
+++ b/src/modules/slurm.c
@@ -5,20 +5,20 @@
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Mark Grondona <mgrondona@llnl.gov>.
  *  UCRL-CODE-2003-005.
- *  
+ *
  *  This file is part of Pdsh, a parallel remote shell program.
  *  For details, see <http://www.llnl.gov/linux/pdsh/>.
- *  
+ *
  *  Pdsh is free software; you can redistribute it and/or modify it under
  *  the terms of the GNU General Public License as published by the Free
  *  Software Foundation; either version 2 of the License, or (at your option)
  *  any later version.
- *  
+ *
  *  Pdsh is distributed in the hope that it will be useful, but WITHOUT ANY
  *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
  *  details.
- *  
+ *
  *  You should have received a copy of the GNU General Public License along
  *  with Pdsh; if not, write to the Free Software Foundation, Inc.,
  *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
@@ -66,9 +66,9 @@ typedef struct listIterator list_itr_t;
 #if STATIC_MODULES
 #  define pdsh_module_info slurm_module_info
 #  define pdsh_module_priority slurm_module_priority
-#endif    
+#endif
 /*
- *  Give this module low priority 
+ *  Give this module low priority
  */
 int pdsh_module_priority = 10;
 
@@ -95,19 +95,19 @@ static List constraint_list = NULL;
  *  Export generic pdsh module options
  */
 struct pdsh_module_operations slurm_module_ops = {
-    (ModInitF)       mod_slurm_init, 
-    (ModExitF)       mod_slurm_exit, 
+    (ModInitF)       mod_slurm_init,
+    (ModExitF)       mod_slurm_exit,
     (ModReadWcollF)  mod_slurm_wcoll,
     (ModPostOpF)     NULL
 };
 
 
-/* 
+/*
  * Export module options
  */
-struct pdsh_module_option slurm_module_options[] = 
- { 
-   { 'j', "jobid,...", 
+struct pdsh_module_option slurm_module_options[] =
+ {
+   { 'j', "jobid,...",
      "Run on nodes allocated to SLURM job(s) (\"all\" = all jobs)",
      DSH | PCP, (optFunc) slurm_process_opt
    },
@@ -122,15 +122,15 @@ struct pdsh_module_option slurm_module_options[] =
    PDSH_OPT_TABLE_END
  };
 
-/* 
- * SLURM module info 
+/*
+ * SLURM module info
  */
 struct pdsh_module pdsh_module_info = {
   "misc",
   "slurm",
   "Mark Grondona <mgrondona@llnl.gov>",
   "Target nodes contained in SLURM jobs or partitions, read SLURM_JOBID by default",
-  DSH | PCP, 
+  DSH | PCP,
 
   &slurm_module_ops,
   NULL,
@@ -149,18 +149,18 @@ static int32_t str2jobid (char *str)
     char *p = NULL;
     long int jid;
 
-    if (str == NULL) 
+    if (str == NULL)
         return (-1);
 
     jid = strtoul (str, &p, 10);
 
-    if (*p != '\0') 
+    if (*p != '\0')
         errx ("%p: invalid setting \"%s\" for -j or SLURM_JOBID\n", str);
 
     return ((int32_t) jid);
 }
 
-    
+
 static int
 slurm_process_opt(opt_t *pdsh_opts, int opt, char *arg)
 {
@@ -335,8 +335,8 @@ static hostlist_t _slurm_wcoll (List joblist)
         return (NULL);
 
     _slurm_init();
-    if (slurm_load_jobs((time_t) NULL, &msg, SHOW_ALL) < 0) 
-        errx ("Unable to contact slurm controller: %s\n", 
+    if (slurm_load_jobs((time_t) NULL, &msg, SHOW_ALL) < 0)
+        errx ("Unable to contact slurm controller: %s\n",
               slurm_strerror (errno));
 
     /*
@@ -359,14 +359,14 @@ static hostlist_t _slurm_wcoll (List joblist)
         }
         else if (_jobid_requested (joblist, j->job_id)) {
             hl = _hl_append (hl, j->nodes);
-            /* 
+            /*
              * Exit when there is no more jobids to search
              */
             if (list_count (joblist) == 0)
                 break;
         }
     }
-    
+
     slurm_free_job_info_msg (msg);
 
     if (hl)

--- a/src/modules/sshcmd.c
+++ b/src/modules/sshcmd.c
@@ -5,31 +5,31 @@
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Jim Garlick <garlick@llnl.gov>.
  *  UCRL-CODE-2003-005.
- *  
+ *
  *  This file is part of Pdsh, a parallel remote shell program.
  *  For details, see <http://www.llnl.gov/linux/pdsh/>.
- *  
+ *
  *  Pdsh is free software; you can redistribute it and/or modify it under
  *  the terms of the GNU General Public License as published by the Free
  *  Software Foundation; either version 2 of the License, or (at your option)
  *  any later version.
- *  
+ *
  *  Pdsh is distributed in the hope that it will be useful, but WITHOUT ANY
  *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
  *  details.
- *  
+ *
  *  You should have received a copy of the GNU General Public License along
  *  with Pdsh; if not, write to the Free Software Foundation, Inc.,
  *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
 \*****************************************************************************/
 
 /*
- * This is an rcmd() replacement originally by Chris Siebenmann 
+ * This is an rcmd() replacement originally by Chris Siebenmann
  * <cks@utcc.utoronto.ca>.  There was no copyright information on the original.
  * If this finds its way back to the original author please let me know if
  * you would like this header block changed...
- * 
+ *
  * Brought in to pdsh from USC rdist -jg
  * Changes:
  * - added fd2p arg handling
@@ -58,7 +58,7 @@
 #include <string.h>             /* memset */
 
 #include <stddef.h>
-#include <sys/socket.h> 
+#include <sys/socket.h>
 #include <sys/wait.h>
 
 #include "src/common/xmalloc.h"
@@ -73,13 +73,13 @@
 #if STATIC_MODULES
 #  define pdsh_module_info sshcmd_module_info
 #  define pdsh_module_priority sshcmd_module_priority
-#endif    
+#endif
 
 #define DEFAULT_SSH_ARGS "-2 -a -x %h"
 
 int pdsh_module_priority = DEFAULT_MODULE_PRIORITY;
 
-    
+
 static int mod_ssh_postop(opt_t *opt);
 static int mod_ssh_exit (void);
 
@@ -112,23 +112,23 @@ struct pdsh_rcmd_operations sshcmd_rcmd_ops = {
     (RcmdDestroyF) sshcmd_destroy
 };
 
-/* 
+/*
  * Export module options
  */
-struct pdsh_module_option sshcmd_module_options[] = 
- { 
+struct pdsh_module_option sshcmd_module_options[] =
+ {
    PDSH_OPT_TABLE_END
  };
 
-/* 
- * Sshcmd module info 
+/*
+ * Sshcmd module info
  */
 struct pdsh_module pdsh_module_info = {
   "rcmd",
   "ssh",
   "Jim Garlick <garlick@llnl.gov>",
   "ssh based rcmd connect method",
-  DSH | PCP, 
+  DSH | PCP,
 
   &sshcmd_module_ops,
   &sshcmd_rcmd_ops,
@@ -153,7 +153,7 @@ static char **ssh_argv_create (List arg_list, const char **remote_argv)
 
     n = 0;
     i = list_iterator_create (arg_list);
-    while ((arg = list_next (i))) 
+    while ((arg = list_next (i)))
         argv[n++] = Strdup (arg);
     list_iterator_destroy (i);
 
@@ -311,13 +311,13 @@ out:
     return (p ? pipecmd_stdoutfd (p) : -1);
 }
 
-static int 
+static int
 sshcmd_destroy (pipecmd_t p)
 {
     int status = 0;
 
     if (pipecmd_wait (p, &status) < 0)
-        err ("%p: %S: wait on ssh cmd: %m\n", pipecmd_target (p));  
+        err ("%p: %S: wait on ssh cmd: %m\n", pipecmd_target (p));
 
     pipecmd_destroy (p);
 

--- a/src/modules/torque.c
+++ b/src/modules/torque.c
@@ -313,7 +313,7 @@ static hostlist_t _torque_wcoll (List joblist)
     }
     else {
         strncpy(servername, status->name, PBS_MAXSERVERNAME);
-        /* Some versions of torque will return server name as FQDN:PORT 
+        /* Some versions of torque will return server name as FQDN:PORT
          * which ends up being in the JobID sent back to the pbs_server.
          */
         strtok(servername, ":");

--- a/src/modules/xcpucmd.c
+++ b/src/modules/xcpucmd.c
@@ -5,20 +5,20 @@
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Jim Garlick <garlick@llnl.gov>.
  *  UCRL-CODE-2003-005.
- *  
+ *
  *  This file is part of Pdsh, a parallel remote shell program.
  *  For details, see <http://www.llnl.gov/linux/pdsh/>.
- *  
+ *
  *  Pdsh is free software; you can redistribute it and/or modify it under
  *  the terms of the GNU General Public License as published by the Free
  *  Software Foundation; either version 2 of the License, or (at your option)
  *  any later version.
- *  
+ *
  *  Pdsh is distributed in the hope that it will be useful, but WITHOUT ANY
  *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
  *  details.
- *  
+ *
  *  You should have received a copy of the GNU General Public License along
  *  with Pdsh; if not, write to the Free Software Foundation, Inc.,
  *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
@@ -69,21 +69,21 @@ struct xcpu_info_struct {
 #if STATIC_MODULES
 #  define pdsh_module_info xcpucmd_module_info
 #  define pdsh_module_priority xcpucmd_module_priority
-#endif    
+#endif
 
 int pdsh_module_priority = DEFAULT_MODULE_PRIORITY;
 
 static int xcpucmd_init(opt_t *);
 static int xcpucmd_signal(int, void *, int);
 static int xcpucmd_destroy(struct xcpu_info_struct *);
-static int xcpucmd(char *, char *, char *, char *, char *, int, int *, void **); 
+static int xcpucmd(char *, char *, char *, char *, char *, int, int *, void **);
 
-/* 
+/*
  * Export pdsh module operations structure
  */
 struct pdsh_module_operations xcpucmd_module_ops = {
-  (ModInitF)       NULL, 
-  (ModExitF)       NULL, 
+  (ModInitF)       NULL,
+  (ModExitF)       NULL,
   (ModReadWcollF)  NULL,
   (ModPostOpF)     NULL,
 };
@@ -100,16 +100,16 @@ struct pdsh_rcmd_operations xcpucmd_xcpucmd_ops = {
 
 
 
-/* 
+/*
  * Export module options
  */
-struct pdsh_module_option xcpucmd_module_options[] = 
- { 
+struct pdsh_module_option xcpucmd_module_options[] =
+ {
    PDSH_OPT_TABLE_END
  };
 
-/* 
- * Xxcpucmd module info 
+/*
+ * Xxcpucmd module info
  */
 struct pdsh_module pdsh_module_info = {
   "rcmd",
@@ -139,7 +139,7 @@ _openclone(char *hostname, int *sidp)
 
     sprintf(path, CLONE_TMPL, hostname);
     f = fopen(path, "r");
-    if (f == NULL) 
+    if (f == NULL)
         err("%s: %m\n", path);
     else if (fscanf(f, "%x", sidp) != 1) {
         err("error reading %s\n", path);
@@ -256,11 +256,11 @@ done:
         fclose(fclone);
     if (fd >= 0)
         *sidp = sid;
-        
+
     return fd; /* session goes away when fd is closed */
 }
 
-static int 
+static int
 xcpucmd_signal(int efd, void *arg, int signum)
 {
     char cmd[256];
@@ -270,9 +270,9 @@ xcpucmd_signal(int efd, void *arg, int signum)
     (void) _writefile(x->hostname, x->sid, "ctl", cmd);
 
     return 0;
-} 
+}
 
-static int 
+static int
 xcpucmd_destroy(struct xcpu_info_struct *x)
 {
     if (x) {
@@ -283,7 +283,7 @@ xcpucmd_destroy(struct xcpu_info_struct *x)
 
     /* XXX Insert retreival of exit status here when we have a wait file. */
 
-    return 0; 
+    return 0;
 }
 
 static int

--- a/src/modules/xrcmd.c
+++ b/src/modules/xrcmd.c
@@ -5,27 +5,27 @@
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Jim Garlick <garlick@llnl.gov>.
  *  UCRL-CODE-2003-005.
- *  
+ *
  *  This file is part of Pdsh, a parallel remote shell program.
  *  For details, see <http://www.llnl.gov/linux/pdsh/>.
- *  
+ *
  *  Pdsh is free software; you can redistribute it and/or modify it under
  *  the terms of the GNU General Public License as published by the Free
  *  Software Foundation; either version 2 of the License, or (at your option)
  *  any later version.
- *  
+ *
  *  Pdsh is distributed in the hope that it will be useful, but WITHOUT ANY
  *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
  *  details.
- *  
+ *
  *  You should have received a copy of the GNU General Public License along
  *  with Pdsh; if not, write to the Free Software Foundation, Inc.,
  *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
 \*****************************************************************************/
 
 /*
- * This code is based on the BSD rcmd.c with MT safety added, and the 
+ * This code is based on the BSD rcmd.c with MT safety added, and the
  * interface changed.  Original UC regents header included below.
  */
 
@@ -64,7 +64,7 @@
 
 /*
  * Changes:
- *  - MT save 
+ *  - MT save
  *  - changed functional interface.
  */
 
@@ -116,20 +116,20 @@ static char sccsid[] = "@(#)rcmd.c	8.3 (Berkeley) 3/26/94";
 #if STATIC_MODULES
 #  define pdsh_module_info xrcmd_module_info
 #  define pdsh_module_priority xrcmd_module_priority
-#endif    
+#endif
 
 int pdsh_module_priority = DEFAULT_MODULE_PRIORITY;
 
 static int xrcmd_init(opt_t *);
 static int xrcmd_signal(int, void *, int);
-static int xrcmd(char *, char *, char *, char *, char *, int, int *, void **); 
+static int xrcmd(char *, char *, char *, char *, char *, int, int *, void **);
 
-/* 
+/*
  * Export pdsh module operations structure
  */
 struct pdsh_module_operations xrcmd_module_ops = {
-  (ModInitF)       NULL, 
-  (ModExitF)       NULL, 
+  (ModInitF)       NULL,
+  (ModExitF)       NULL,
   (ModReadWcollF)  NULL,
   (ModPostOpF)     NULL,
 };
@@ -143,23 +143,23 @@ struct pdsh_rcmd_operations xrcmd_rcmd_ops = {
     (RcmdF)      xrcmd,
 };
 
-/* 
+/*
  * Export module options
  */
-struct pdsh_module_option xrcmd_module_options[] = 
- { 
+struct pdsh_module_option xrcmd_module_options[] =
+ {
    PDSH_OPT_TABLE_END
  };
 
-/* 
- * Xrcmd module info 
+/*
+ * Xrcmd module info
  */
 struct pdsh_module pdsh_module_info = {
   "rcmd",
   "rsh",
   "Jim Garlick <garlick@llnl.gov>",
   "BSD rcmd connect method",
-  DSH | PCP, 
+  DSH | PCP,
 
   &xrcmd_module_ops,
   &xrcmd_rcmd_ops,

--- a/src/pdsh/dsh.h
+++ b/src/pdsh/dsh.h
@@ -5,20 +5,20 @@
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Jim Garlick <garlick@llnl.gov>.
  *  UCRL-CODE-2003-005.
- *  
+ *
  *  This file is part of Pdsh, a parallel remote shell program.
  *  For details, see <http://www.llnl.gov/linux/pdsh/>.
- *  
+ *
  *  Pdsh is free software; you can redistribute it and/or modify it under
  *  the terms of the GNU General Public License as published by the Free
  *  Software Foundation; either version 2 of the License, or (at your option)
  *  any later version.
- *  
+ *
  *  Pdsh is distributed in the hope that it will be useful, but WITHOUT ANY
  *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
  *  details.
- *  
+ *
  *  You should have received a copy of the GNU General Public License along
  *  with Pdsh; if not, write to the Free Software Foundation, Inc.,
  *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
@@ -82,7 +82,7 @@ typedef struct thd {
     int rc;                     /* remote return code (-S) */
     int nodeid;                 /* node index */
     int nnodes;                 /* number of nodes in job */
-    
+
     struct rcmd_info *rcmd;     /* rcmd connection info */
 
     cbuf_t outbuf;              /* output buffer */

--- a/src/pdsh/main.c
+++ b/src/pdsh/main.c
@@ -5,20 +5,20 @@
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Jim Garlick <garlick@llnl.gov>.
  *  UCRL-CODE-2003-005.
- *  
+ *
  *  This file is part of Pdsh, a parallel remote shell program.
  *  For details, see <http://www.llnl.gov/linux/pdsh/>.
- *  
+ *
  *  Pdsh is free software; you can redistribute it and/or modify it under
  *  the terms of the GNU General Public License as published by the Free
  *  Software Foundation; either version 2 of the License, or (at your option)
  *  any later version.
- *  
+ *
  *  Pdsh is distributed in the hope that it will be useful, but WITHOUT ANY
  *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
  *  details.
- *  
+ *
  *  You should have received a copy of the GNU General Public License along
  *  with Pdsh; if not, write to the Free Software Foundation, Inc.,
  *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
@@ -81,7 +81,7 @@ int main(int argc, char *argv[])
     err_init(prog);       /* init err package */
 
     /*
-     *  If running setuid, fork a child to handle 
+     *  If running setuid, fork a child to handle
      *   all privileged operations and drop privs in this process.
      */
     privsep_init();
@@ -127,7 +127,7 @@ int main(int argc, char *argv[])
          */
         if (opt.info_only)      /* display info only */
             opt_list(&opt);
-        else if (pdsh_personality() == PCP && opt.pcp_server) 
+        else if (pdsh_personality() == PCP && opt.pcp_server)
             retval = (_pcp_remote_server (&opt) < 0);
         else if (pdsh_personality() == PCP && opt.pcp_client)
             retval = (_pcp_remote_client (&opt) < 0);
@@ -139,7 +139,7 @@ int main(int argc, char *argv[])
         retval = 1;
     }
 
-    mod_exit(); 
+    mod_exit();
 
     /*
      * Clean up.
@@ -174,7 +174,7 @@ static int _history_file_create (char *path, size_t len)
         return (-1);
     }
 
-    /*  Check for ~/.pdsh directory 
+    /*  Check for ~/.pdsh directory
      *    and create if it does not exist
      */
     if (lstat (path, &sbuf) < 0) {
@@ -209,7 +209,7 @@ static int _history_file_create (char *path, size_t len)
     close (fd);
 
     if ((rc = read_history (path))) {
-        err ("%p: Warning: Unable to read history file \"%s\": %s\n", 
+        err ("%p: Warning: Unable to read history file \"%s\": %s\n",
                 path, strerror (rc));
         return (-1);
     }
@@ -249,7 +249,7 @@ static void _interactive_dsh(opt_t * opt)
 
     if (_history_file_create (history_filename, len) < 0) {
         got_history_file = 0;
-    } 
+    }
 
     while ((cmd = readline(prompt)) != NULL) {
         int   errnum;
@@ -267,7 +267,7 @@ static void _interactive_dsh(opt_t * opt)
         }
 
         cmd = expansion;
- 
+
         if (!strcmp(cmd, "history")) {
             _history_list ();
             continue;
@@ -284,11 +284,11 @@ static void _interactive_dsh(opt_t * opt)
             break;
         }
 
-        if ((strlen(cmd) != 0) && (got_history_file)) 
+        if ((strlen(cmd) != 0) && (got_history_file))
             append_history (1, history_filename);
 
-        /* 
-         * fork dsh so we can ignore SIGINT in prompt loop 
+        /*
+         * fork dsh so we can ignore SIGINT in prompt loop
          */
         switch (pid = fork()) {
         case -1:               /* error */
@@ -358,8 +358,8 @@ static void _interactive_dsh(opt_t * opt)
 
 /*
  * Run a command that was shell-escaped from the dsh> prompt.  Run it as
- * the real uid of the invoking user, so we must fork to maintain root 
- * effective uid in the parent. 
+ * the real uid of the invoking user, so we must fork to maintain root
+ * effective uid in the parent.
  *	uid (IN)	uid used to execute command
  *	cmd (IN)	command and args
  */
@@ -383,8 +383,8 @@ static void _shell(uid_t uid, char *cmd)
     }
 }
 
-/* 
- * Prompt for a command and return it.  
+/*
+ * Prompt for a command and return it.
  *	prompt (IN)	string used to build prompt (e.g. program name)
  */
 static char *_getcmd(char *prompt)

--- a/src/pdsh/mod.c
+++ b/src/pdsh/mod.c
@@ -5,20 +5,20 @@
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Jim Garlick <garlick@llnl.gov>.
  *  UCRL-CODE-2003-005.
- *  
+ *
  *  This file is part of Pdsh, a parallel remote shell program.
  *  For details, see <http://www.llnl.gov/linux/pdsh/>.
- *  
+ *
  *  Pdsh is free software; you can redistribute it and/or modify it under
  *  the terms of the GNU General Public License as published by the Free
  *  Software Foundation; either version 2 of the License, or (at your option)
  *  any later version.
- *  
+ *
  *  Pdsh is distributed in the hope that it will be useful, but WITHOUT ANY
  *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
  *  details.
- *  
+ *
  *  You should have received a copy of the GNU General Public License along
  *  with Pdsh; if not, write to the Free Software Foundation, Inc.,
  *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
@@ -42,7 +42,7 @@
 #include "static_modules.h"
 #else
 #include "dlfcn.h"
-#endif 
+#endif
 
 #include "src/common/err.h"
 #include "src/common/xmalloc.h"
@@ -53,7 +53,7 @@
 #include "mod.h"
 
 /*
- * pdsh/322: Workaround apparent bug in glibc 2.2.4 which 
+ * pdsh/322: Workaround apparent bug in glibc 2.2.4 which
  * occaisionally causes LinuxThreads manager thread to
  * segfault at exit. (Disable dlclose() and lt_dlexit()
  * in these versions of glibc)
@@ -91,7 +91,7 @@ typedef enum permission_error {
 } perm_error_t;
 
 
-/* 
+/*
  *  Static function prototypes:
  */
 #if STATIC_MODULES
@@ -101,7 +101,7 @@ static int  _mod_load_static(int);
 static int  _mod_load_dynamic_modules(const char *, opt_t *);
 static int  _mod_load_dynamic(const char *, opt_t *);
 static int  _cmp_filenames(mod_t, char *);
-static int  _is_loaded(char *filename); 
+static int  _is_loaded(char *filename);
 static bool _path_permissions_ok(const char *dir, uid_t pdsh_owner);
 static perm_error_t  _dir_permission_error(struct stat *, uid_t alt_uid);
 #endif
@@ -140,11 +140,11 @@ mod_exit(void)
         return 0;
 
     /*
-     *  list_destroy() will call module destructor on each 
+     *  list_destroy() will call module destructor on each
      *    element in list
      */
     list_destroy(module_list);
-    
+
     return 0;
 }
 
@@ -185,15 +185,15 @@ static mod_t _mod_next_active (ListIterator i)
 
 /*
  *  Call any "read wcoll" functions exported by modules. The module
- *    is responsible for deciding when to generate a new wcoll, 
+ *    is responsible for deciding when to generate a new wcoll,
  *    append to existing wcoll, etc. (presumably based on the contents
  *    of opt)
  *
  *  This function appends to wcoll any new hosts returned from the
- *    module specific read_wcoll() functions. 
+ *    module specific read_wcoll() functions.
  *
  *  Returns -1 on error, 0 for success.
- */  
+ */
 int
 mod_read_wcoll(opt_t *opt)
 {
@@ -285,7 +285,7 @@ _mod_destroy(mod_t mod)
 
     if (mod->filename)
         Free((void **) &mod->filename);
-    
+
 #if !STATIC_MODULES
 #  if !PREVENT_DLCLOSE_BUG
     if (mod->handle)
@@ -379,14 +379,14 @@ int mod_load_modules(const char *dir, opt_t *opt)
  *  Print all options from module option table 'p,' aligning description
  *    with column 'col'
  */
-static void 
+static void
 _print_option_help(struct pdsh_module_option *p, int col)
 {
     char buf[81];
 
     assert(p != NULL);
 
-    snprintf(buf, 81, "-%c %-*s %s\n", p->opt, col - 4, 
+    snprintf(buf, 81, "-%c %-*s %s\n", p->opt, col - 4,
              (p->arginfo ? p->arginfo : ""), p->descr);
 
     err("%s", buf);
@@ -403,24 +403,24 @@ mod_print_options(mod_t mod, int col)
     p = mod->pmod->opt_table;
     if (!p || !p->opt)
         return;
-    /* 
+    /*
      * out("%s/%s Options:\n", mod->pmod->type, mod->pmod->name);
      */
-    for (p = mod->pmod->opt_table; p && (p->opt != 0); p++) 
+    for (p = mod->pmod->opt_table; p && (p->opt != 0); p++)
         _print_option_help(p, col);
-        
+
 }
 
 /*
  *  Print to stdout information stanza for module "mod"
  */
-static int 
+static int
 _mod_print_info(mod_t mod)
 {
-    if (mod == NULL) 
+    if (mod == NULL)
         return 0;
 
-    out("Module: %s/%s\n",    mod->pmod->type, mod->pmod->name); 
+    out("Module: %s/%s\n",    mod->pmod->type, mod->pmod->name);
     out("Author: %s\n",       mod->pmod->author ? mod->pmod->author : "???");
     out("Descr:  %s\n",       mod->pmod->descr ? mod->pmod->descr : "???");
     out("Active: %s\n",       mod->initialized ? "yes" : "no");
@@ -443,7 +443,7 @@ static int _opt_print(mod_t mod, int *col)
 }
 
 
-void mod_print_all_options(int col) 
+void mod_print_all_options(int col)
 {
     list_for_each(module_list, (ListForF) _opt_print, &col);
 }
@@ -471,7 +471,7 @@ mod_count(char *type)
         return -1;
     }
 
-    while (list_find(module_itr, (ListFindF) _cmp_type, type)) 
+    while (list_find(module_itr, (ListFindF) _cmp_type, type))
         i++;
 
     list_iterator_destroy(module_itr);
@@ -628,7 +628,7 @@ mod_get_rcmd_destroy (mod_t mod)
 {
     assert (mod != NULL);
     assert (mod->pmod != NULL);
-    
+
     if (mod->pmod->rcmd_ops && mod->pmod->rcmd_ops->rcmd_destroy)
         return mod->pmod->rcmd_ops->rcmd_destroy;
     else
@@ -636,7 +636,7 @@ mod_get_rcmd_destroy (mod_t mod)
 }
 
 
-int 
+int
 mod_process_opt(opt_t *opt, int c, char *optarg)
 {
     mod_t mod;
@@ -669,12 +669,12 @@ static struct pdsh_module_option *
 _mod_find_opt(mod_t mod, int opt)
 {
   struct pdsh_module_option *p = mod->pmod->opt_table;
-  for (p = mod->pmod->opt_table; p && (p->opt != 0); p++) 
+  for (p = mod->pmod->opt_table; p && (p->opt != 0); p++)
       if (p->opt == opt) return p;
   return NULL;
 }
 
-static int 
+static int
 _mod_delete (const char *type, const char *name)
 {
     ListIterator i = list_iterator_create (module_list);
@@ -691,8 +691,8 @@ _mod_delete (const char *type, const char *name)
 static int _mod_register (mod_t mod, const char *name)
 {
     mod_t prev;
-    /* 
-     *  Must have atleast a name and type 
+    /*
+     *  Must have atleast a name and type
      */
     if (!mod->pmod->type || !mod->pmod->name) {
         err("%p:[%s] type or name not specified in module\n", name);
@@ -704,8 +704,8 @@ static int _mod_register (mod_t mod, const char *name)
      *   Delete previous module if its priority is higher.
      */
     if ((prev = mod_get_module (mod->pmod->type, mod->pmod->name))) {
-        err("%p: %s: [%s/%s] already loaded from [%s]\n", 
-                mod->filename, mod->pmod->type, mod->pmod->name, 
+        err("%p: %s: [%s/%s] already loaded from [%s]\n",
+                mod->filename, mod->pmod->type, mod->pmod->name,
                 prev->filename);
         if (mod->priority > prev->priority)
             _mod_delete (mod->pmod->type, mod->pmod->name);
@@ -713,8 +713,8 @@ static int _mod_register (mod_t mod, const char *name)
             return (-1);
     }
 
-    /* 
-     * Continue with module loading only if personality acceptable 
+    /*
+     * Continue with module loading only if personality acceptable
      */
     if (!(mod->pmod->personality & pdsh_personality()))
         return -1;
@@ -729,10 +729,10 @@ static int _mod_initialize (mod_t mod)
     if (!_mod_opts_ok(mod))
         return -1;
 
-    if (mod->pmod->mod_ops && 
-        mod->pmod->mod_ops->init && 
+    if (mod->pmod->mod_ops &&
+        mod->pmod->mod_ops->init &&
         ((*mod->pmod->mod_ops->init)() < 0)) {
-        err("%p: error: %s/%s failed to initialize.\n", 
+        err("%p: error: %s/%s failed to initialize.\n",
             mod->pmod->type, mod->pmod->name);
         return -1;
     }
@@ -775,7 +775,7 @@ _mod_load_static(int idx)
 /*
  *  Load all statically defined modules from internal static_mods array
  */
-static int 
+static int
 _mod_load_static_modules(void)
 {
     int i = 0;
@@ -821,18 +821,18 @@ _mod_load_dynamic(const char *fq_path, opt_t *pdsh_opts)
     if (_is_loaded(mod->filename)) {
         /* Module already loaded. This is OK, no need for
          *   error message. (Could have already opened a .la and
-         *   we are now opening the corresponding .so 
+         *   we are now opening the corresponding .so
          */
         goto fail;
     }
-  
+
     /* load all module info from the pdsh_module structure */
     if (!(mod->pmod = dlsym(mod->handle, "pdsh_module_info"))) {
         err("%p:[%s] can't resolve pdsh module\n", mod->filename);
         goto fail;
     }
 
-    if ((priority = dlsym(mod->handle, "pdsh_module_priority"))) 
+    if ((priority = dlsym(mod->handle, "pdsh_module_priority")))
         mod->priority = *priority;
 
     if (_mod_register(mod, mod->filename) < 0)
@@ -845,11 +845,11 @@ _mod_load_dynamic(const char *fq_path, opt_t *pdsh_opts)
     return -1;
 }
 
-static int  
+static int
 _pdsh_owner(const char *pdsh_path, uid_t *pdsh_uid)
 {
     struct stat st;
-  
+
     if (stat (pdsh_path, &st) < 0) {
         err ("%p: Unable to determine ownership of pdsh binary: %m\n");
         return -1;
@@ -873,13 +873,13 @@ _mod_load_dynamic_modules(const char *dir, opt_t *pdsh_opts)
     assert(dir != NULL);
     assert(*dir != '\0');
 
-    if (!initialized) 
+    if (!initialized)
         mod_init();
 
     if (_pdsh_owner(pdsh_opts->local_program_path, &pdsh_owner) < 0)
         return -1;
 
-    if (!_path_permissions_ok(dir, pdsh_owner)) 
+    if (!_path_permissions_ok(dir, pdsh_owner))
         return -1;
 
     if (!(dirp = opendir(dir)))
@@ -895,14 +895,14 @@ _mod_load_dynamic_modules(const char *dir, opt_t *pdsh_opts)
         strcpy(p, entry->d_name);
 
         if (stat(path, &st) < 0)
-            continue; 
+            continue;
         if (!S_ISREG(st.st_mode))
             continue;
 
         /*
          *  Do not load modules that could have been altered by
          *   a user other than root or the current user or the user
-         *   owning the pdsh executable. Otherwise pdsh could execute 
+         *   owning the pdsh executable. Otherwise pdsh could execute
          *   arbitrary code.
          */
         if (  (st.st_uid != 0) && (st.st_uid != getuid())
@@ -914,7 +914,7 @@ _mod_load_dynamic_modules(const char *dir, opt_t *pdsh_opts)
             err ("%p: skipping insecure module \"%s\" (check perms)\n", path);
             continue;
         }
-        
+
         if (_mod_load_dynamic(path, pdsh_opts) < 0)
             continue;
 
@@ -925,7 +925,7 @@ _mod_load_dynamic_modules(const char *dir, opt_t *pdsh_opts)
         err("%p: error closing %s: %m", dir);
 
     if (count == 0)
-        errx("%p: no modules found\n"); 
+        errx("%p: no modules found\n");
 
     return 0;
 }
@@ -945,11 +945,11 @@ _is_loaded(char *filename)
     return 0;
 }
 
-static char * 
+static char *
 _perm_error_string (perm_error_t error)
 {
     switch (error) {
-        case DIR_OK: 
+        case DIR_OK:
             return ("Permissions are valid");
         case DIR_NOT_DIRECTORY:
             return ("Not a directory");
@@ -977,8 +977,8 @@ _dir_permission_error(struct stat *st, uid_t alt_uid)
 {
     if (!S_ISDIR(st->st_mode))
         return DIR_NOT_DIRECTORY;
-    if (  (st->st_uid != 0) && (st->st_uid != getuid()) 
-       && (st->st_uid != alt_uid)) 
+    if (  (st->st_uid != 0) && (st->st_uid != getuid())
+       && (st->st_uid != alt_uid))
         return DIR_BAD_OWNER;
     if ((st->st_mode & S_IWOTH) && !(st->st_mode & S_ISVTX))
         return DIR_WORLD_WRITABLE;
@@ -987,7 +987,7 @@ _dir_permission_error(struct stat *st, uid_t alt_uid)
 
 /*
  *  Temprarily chdir() to path and use getcwd to return real patch
- *   to caller. 
+ *   to caller.
  */
 static char *
 _get_dir_name (const char *path, char *buf, size_t len)
@@ -996,7 +996,7 @@ _get_dir_name (const char *path, char *buf, size_t len)
     char * orig_path = Malloc (pathlen * sizeof (char));
 
     while (!getcwd (orig_path, pathlen) && (pathlen < MAXPATHLEN*2))
-        Realloc ((void **) &orig_path, pathlen*=2 * sizeof (char)); 
+        Realloc ((void **) &orig_path, pathlen*=2 * sizeof (char));
 
     if (chdir (path) < 0)
         errx ("Unable to chdir() to %s: %m", path);
@@ -1015,7 +1015,7 @@ _get_dir_name (const char *path, char *buf, size_t len)
 }
 
 /*
- *  Returns true if, for the directory "dir" and all of its parent 
+ *  Returns true if, for the directory "dir" and all of its parent
  *    directories,  the following are true:
  *    - ownership is root or the calling user (as returned by getuid())
  *        or same ownership as the pdsh or pdcp binary.
@@ -1059,9 +1059,9 @@ _path_permissions_ok(const char *dir, uid_t pdsh_owner)
         if ((error = _dir_permission_error(&st, pdsh_owner)) != DIR_OK) {
             char buf [MAXPATHLEN];
             err("%p: module path \"%s\" insecure.\n", dir);
-            err("%p: \"%s\": %s\n", 
-                _get_dir_name (dirbuf, buf, MAXPATHLEN), 
-                _perm_error_string (error)); 
+            err("%p: \"%s\": %s\n",
+                _get_dir_name (dirbuf, buf, MAXPATHLEN),
+                _perm_error_string (error));
             return false;
         }
 

--- a/src/pdsh/mod.h
+++ b/src/pdsh/mod.h
@@ -5,20 +5,20 @@
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Mark Grondona <mgrondona@llnl.gov>.
  *  UCRL-CODE-2003-005.
- *  
+ *
  *  This file is part of Pdsh, a parallel remote shell program.
  *  For details, see <http://www.llnl.gov/linux/pdsh/>.
- *  
+ *
  *  Pdsh is free software; you can redistribute it and/or modify it under
  *  the terms of the GNU General Public License as published by the Free
  *  Software Foundation; either version 2 of the License, or (at your option)
  *  any later version.
- *  
+ *
  *  Pdsh is distributed in the hope that it will be useful, but WITHOUT ANY
  *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
  *  details.
- *  
+ *
  *  You should have received a copy of the GNU General Public License along
  *  with Pdsh; if not, write to the Free Software Foundation, Inc.,
  *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
@@ -28,7 +28,7 @@
 
 #if HAVE_CONFIG_H
 #  include <config.h>
-#endif 
+#endif
 
 #include "src/pdsh/opt.h"
 
@@ -46,18 +46,18 @@ int mod_init(void);
  *  Finalize and close the module loader interface.
  *    Cycles through list of loaded modules and runs each modules
  *    "exit" routine if one was exported. Then frees memory associated
- *    with the module and unloads it. 
+ *    with the module and unloads it.
  *
  *  Returns 0 for Success and -1 for Failure.
  */
 int mod_exit(void);
 
 /*
- *  Load all modules from specified directory. 
- *    Directory must be owned by the current user and not writable 
- *    by any other user.  After successfully loading each module, 
- *    the module's "init" routine is called and module command line 
- *    options are registered.  The module is not loaded if init 
+ *  Load all modules from specified directory.
+ *    Directory must be owned by the current user and not writable
+ *    by any other user.  After successfully loading each module,
+ *    the module's "init" routine is called and module command line
+ *    options are registered.  The module is not loaded if init
  *    returns < 0 or any module option cannot be registered.
  *
  *  If modules are being compiled statically, the directory argument
@@ -73,7 +73,7 @@ int mod_load_modules(const char *dir, opt_t *opt);
 void mod_list_module_info(void);
 
 /*
- *  Traverse through loaded modules and attempt to process 
+ *  Traverse through loaded modules and attempt to process
  *    option `opt' with argument `arg.'
  *
  *  Note: Only one module exporting a given option can be loaded
@@ -82,7 +82,7 @@ void mod_list_module_info(void);
 int mod_process_opt(opt_t *pdsh_opts, int opt, char *arg);
 
 /*
- *  Traverses list of loaded modules, calling any exported "read_wcoll" 
+ *  Traverses list of loaded modules, calling any exported "read_wcoll"
  *    routines. Appends any returned results onto opt->wcoll.
  *
  *  This routine should only be called from within pdsh/opt.c after
@@ -134,14 +134,14 @@ List mod_get_uninitialized_module_names (char *type);
  */
 void mod_print_all_options(int column);
 
-/* 
+/*
  *  Print options for module "mod"
  */
 void mod_print_options(mod_t mod, int descr_column);
 
 /*
  * Functions that may be exported by any pdsh module
- *   via a pdsh_module_operations structure. 
+ *   via a pdsh_module_operations structure.
  */
 typedef int        (*ModInitF)      (void);
 typedef int        (*ModExitF)      (void);
@@ -150,7 +150,7 @@ typedef int        (*ModPostOpF)    (opt_t *);
 
 /*
  * Functions that may be exported by any rcmd module
- *   via a pdsh_rcmd_operations structure. 
+ *   via a pdsh_rcmd_operations structure.
  */
 typedef int        (*RcmdInitF)     (opt_t *);
 typedef int        (*RcmdSigF)      (int, void *, int);
@@ -173,8 +173,8 @@ RcmdF        mod_get_rcmd(mod_t mod);
 RcmdDestroyF mod_get_rcmd_destroy(mod_t mod);
 
 
-/* 
- * Store all module operations of a module 
+/*
+ * Store all module operations of a module
  */
 struct pdsh_module_operations {
     ModInitF      init;         /* Called just after module is loaded      */
@@ -182,13 +182,13 @@ struct pdsh_module_operations {
 
     ModReadWcollF read_wcoll;   /* Called if wcoll is not initialized at
                                    end of option processing. First wcoll
-                                   returned by a module will be used.      */ 
+                                   returned by a module will be used.      */
 
     ModPostOpF    postop;       /* Called after argv option processing     */
 };
 
-/* 
- * Stores all rcmd operations of a module 
+/*
+ * Stores all rcmd operations of a module
  */
 struct pdsh_rcmd_operations {
     RcmdInitF    rcmd_init;
@@ -197,12 +197,12 @@ struct pdsh_rcmd_operations {
     RcmdDestroyF rcmd_destroy;
 };
 
-/* 
- * Stores all information about a module 
+/*
+ * Stores all information about a module
  */
 struct pdsh_module {
     char *type;        /* module type, e.g. Jedi */
-    char *name;        /* module name, e.g. Yoda */ 
+    char *name;        /* module name, e.g. Yoda */
     char *author;      /* module author, e.g. George Lucas */
     char *descr;       /* module description, e.g. "Run pdsh with the force */
     int personality;   /* personality mask for module (DSH, PCP, or DSH|PCP */
@@ -214,6 +214,6 @@ struct pdsh_module {
 
 #endif /* !_MOD_H */
 
-/* 
+/*
  * vi: tabstop=4 shiftwidth=4 expandtab
  */

--- a/src/pdsh/opt.c
+++ b/src/pdsh/opt.c
@@ -135,6 +135,11 @@ static char *pdsh_options = NULL;
 static pers_t personality = DSH;
 
 /*
+ *  Debug mode
+ */
+static bool debug = false;
+
+/*
  *  Return the current pdsh "personality"
  */
 pers_t pdsh_personality(void)
@@ -205,8 +210,15 @@ bool opt_register(struct pdsh_module_option *opt_table)
      */
     for (p = opt_table; p && (p->opt != 0); p++) {
         if (  (personality & p->personality) 
-           && (strchr(pdsh_options, p->opt) != NULL))
+           && (strchr(pdsh_options, p->opt) != NULL)) {
+            if (debug) {
+                err("%p: Option %c in use by a previously loaded module.\n",
+                    p->opt);
+                err("%p: Module options currently in use are: %s\n",
+                    pdsh_options);
+            }
             return false;
+        }
     }
 
     for (p = opt_table; p && (p->opt != 0); p++) {
@@ -529,6 +541,10 @@ void opt_args_early (opt_t * opt, int argc, char *argv[])
                 break;
             case 'd':              /* debug */
                 opt->debug = true;
+                /*  Also set global debug flag to get module option
+                 *  debugging.
+                 */
+                debug = true;
                 break;
         }
     }

--- a/src/pdsh/opt.c
+++ b/src/pdsh/opt.c
@@ -5,20 +5,20 @@
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Jim Garlick <garlick@llnl.gov>.
  *  UCRL-CODE-2003-005.
- *  
+ *
  *  This file is part of Pdsh, a parallel remote shell program.
  *  For details, see <http://www.llnl.gov/linux/pdsh/>.
- *  
+ *
  *  Pdsh is free software; you can redistribute it and/or modify it under
  *  the terms of the GNU General Public License as published by the Free
  *  Software Foundation; either version 2 of the License, or (at your option)
  *  any later version.
- *  
+ *
  *  Pdsh is distributed in the hope that it will be useful, but WITHOUT ANY
  *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
  *  details.
- *  
+ *
  *  You should have received a copy of the GNU General Public License along
  *  with Pdsh; if not, write to the Free Software Foundation, Inc.,
  *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
@@ -52,7 +52,7 @@
 #include "src/common/split.h"
 #include "src/common/xstring.h"
 #include "src/common/xmalloc.h"
-#include "dsh.h"                
+#include "dsh.h"
 #include "opt.h"
 #include "wcoll.h"
 #include "mod.h"
@@ -126,7 +126,7 @@ Usage: rpdcp [-options] src [src2...] dir\n\
  *  Pdsh options string (for getopt) -- initialized
  *    in _init_pdsh_options(), and appended to by modules that
  *    register new pdsh options.
- */    
+ */
 static char *pdsh_options = NULL;
 
 /*
@@ -198,18 +198,18 @@ _init_pdsh_options()
 bool opt_register(struct pdsh_module_option *opt_table)
 {
     struct pdsh_module_option *p;
-  
+
     if (opt_table == NULL)
         return true;
 
     if (pdsh_options == NULL)
         _init_pdsh_options();
-    
+
     /*  Don't register any options if we can't register all the options
-     *   in this module 
+     *   in this module
      */
     for (p = opt_table; p && (p->opt != 0); p++) {
-        if (  (personality & p->personality) 
+        if (  (personality & p->personality)
            && (strchr(pdsh_options, p->opt) != NULL)) {
             if (debug) {
                 err("%p: Option %c in use by a previously loaded module.\n",
@@ -247,7 +247,7 @@ char * _check_path(char *dir, char *cwd, char *argv0)
   xstrcat(&abspath, dir);
   xstrcat(&abspath, "/");
   xstrcat(&abspath, argv0);
-  
+
   if (access(abspath, R_OK) == 0)
       return abspath;
 
@@ -259,7 +259,7 @@ char * _check_path(char *dir, char *cwd, char *argv0)
 /*
  *  Determine absolute path to the program name based on argv0
  */
-char * _find_path(char *argv0) 
+char * _find_path(char *argv0)
 {
     char *abspath = NULL;
     char cwd[MAXPATHLEN];
@@ -270,9 +270,9 @@ char * _find_path(char *argv0)
         goto done;
     }
 
-    if (getcwd(cwd, MAXPATHLEN) == NULL) 
-        errx("%p: getcwd failed: %m\n"); 
-      
+    if (getcwd(cwd, MAXPATHLEN) == NULL)
+        errx("%p: getcwd failed: %m\n");
+
     if (*argv0 == '.' || strchr(argv0, '/') != NULL) {
         /* path relative */
         abspath = Strdup(cwd);
@@ -282,14 +282,14 @@ char * _find_path(char *argv0)
     else {
       /* argv0 executed in PATH environment var */
       char *path, *dir, *p;
-      
+
       if ((path = Strdup(getenv("PATH"))) == NULL)
-        errx("%p: getenv PATH failed\n"); 
-      
+        errx("%p: getenv PATH failed\n");
+
       dir = path;
       while ((p = strchr(dir,':')) != NULL) {
         *p = '\0';
-        
+
         if (strlen(dir) > 0 && (abspath = _check_path(dir,cwd,argv0)) != NULL) {
             Free((void **) &path);
             goto done;
@@ -297,10 +297,10 @@ char * _find_path(char *argv0)
 
         dir = ++p;
       }
-      
+
       if (strlen(dir) > 0)
           abspath = _check_path(dir,cwd,argv0);
-        
+
       Free((void **) &path);
     }
 
@@ -358,7 +358,7 @@ void opt_default(opt_t * opt, char *argv0)
 
     if (!strcmp(opt->progname, "pdsh") || !strcmp(opt->progname, "dsh"))
         personality = DSH;
-    else if (!strcmp(opt->progname, "pdcp") 
+    else if (!strcmp(opt->progname, "pdcp")
             || !strcmp(opt->progname, "dcp")
             || !strcmp(opt->progname, "pcp") )
         personality = PCP;
@@ -396,7 +396,7 @@ void opt_default(opt_t * opt, char *argv0)
     /*
      *  Resolve hostnames by default
      */
-    opt->resolve_hosts = true; 
+    opt->resolve_hosts = true;
 
     /*
      *  Do not kill all tasks on single failure by default
@@ -614,7 +614,7 @@ void opt_args(opt_t * opt, int argc, char *argv[])
             mod_list_module_info();
             exit(0);
             break;
-        case 'R': 
+        case 'R':
             opt->rcmd_name = Strdup(optarg);
             break;
         case 'S':              /* get remote command status */
@@ -688,7 +688,7 @@ void opt_args(opt_t * opt, int argc, char *argv[])
             _usage(opt);
             break;
         case 'K':              /* don't strip host domain in output */
-            err_no_strip_domain (); 
+            err_no_strip_domain ();
             break;
         case 'y':
             if (pdsh_personality() == PCP)
@@ -727,7 +727,7 @@ void opt_args(opt_t * opt, int argc, char *argv[])
             exit(1);
 
 
-    /* 
+    /*
      *  Save beginning of remote argv in case something needs
      *   to view the unadulterated version (after shell quoting
      *   applied, etc.)
@@ -746,7 +746,7 @@ void opt_args(opt_t * opt, int argc, char *argv[])
     } else {
         if (!opt->infile_names)
             opt->infile_names = list_create(NULL);
-        
+
         for (; optind < argc - 1; optind++)
             list_append(opt->infile_names, argv[optind]);
         if (optind < argc) {
@@ -819,7 +819,7 @@ static void wcoll_expand (opt_t *opt)
 }
 
 
-/* 
+/*
  * Check if infile_names are legit.
  */
 static int
@@ -872,7 +872,7 @@ bool opt_verify(opt_t * opt)
         verified = false;
     }
 
-    if (!opt->pcp_server && !opt->pcp_client) { 
+    if (!opt->pcp_server && !opt->pcp_client) {
         /* wcoll is required */
         if (opt->wcoll == NULL || hostlist_count(opt->wcoll) == 0) {
             err("%p: no remote hosts specified\n");
@@ -1129,7 +1129,7 @@ static char *_rcmd_module_list(char *buf, int maxlen)
     n = _module_list_string ("rcmd", rbuf, sizeof (rbuf));
 
     len = snprintf(buf, maxlen, "%s", n ? rbuf : "(none)");
-    if ((len < 0) || (len >= maxlen)) 
+    if ((len < 0) || (len >= maxlen))
         goto done;
 
     if (mod_count("rcmd") > 1) {
@@ -1143,15 +1143,15 @@ static char *_rcmd_module_list(char *buf, int maxlen)
     }
 
 done:
-    if ((len < 0) || (len > maxlen)) 
-        snprintf(buf + maxlen - 12, 12, "[truncated]"); 
+    if ((len < 0) || (len > maxlen))
+        snprintf(buf + maxlen - 12, 12, "[truncated]");
 
     buf[maxlen - 1] = '\0';
     return buf;
 }
 
 /*
- * Spit out all the options and their one-line synopsis for the user, 
+ * Spit out all the options and their one-line synopsis for the user,
  * then exit.
  */
 static void _usage(opt_t * opt)
@@ -1165,7 +1165,7 @@ static void _usage(opt_t * opt)
 #endif
     } else if (!opt->reverse_copy) /* PCP */
         err(OPT_USAGE_PCP);
-    else 
+    else
         err(OPT_USAGE_RPCP);
 
     err(OPT_USAGE_COMMON);
@@ -1207,7 +1207,7 @@ static void _show_version(void)
  *    of the string in rptr. Returns nonzero if an rcmd_type was found,
  *    zero otherwise (in which case rptr is not touched).
  */
-static int get_host_rcmd_type (char *hosts, char **rptr, char **hptr, 
+static int get_host_rcmd_type (char *hosts, char **rptr, char **hptr,
                                char **uptr)
 {
     char *p = hosts;

--- a/src/pdsh/opt.h
+++ b/src/pdsh/opt.h
@@ -5,20 +5,20 @@
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Jim Garlick <garlick@llnl.gov>.
  *  UCRL-CODE-2003-005.
- *  
+ *
  *  This file is part of Pdsh, a parallel remote shell program.
  *  For details, see <http://www.llnl.gov/linux/pdsh/>.
- *  
+ *
  *  Pdsh is free software; you can redistribute it and/or modify it under
  *  the terms of the GNU General Public License as published by the Free
  *  Software Foundation; either version 2 of the License, or (at your option)
  *  any later version.
- *  
+ *
  *  Pdsh is distributed in the hope that it will be useful, but WITHOUT ANY
  *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
  *  details.
- *  
+ *
  *  You should have received a copy of the GNU General Public License along
  *  with Pdsh; if not, write to the Free Software Foundation, Inc.,
  *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
@@ -66,10 +66,10 @@ typedef struct {
     int command_timeout;
 
     char *rcmd_name;            /* -R name   */
-    char *misc_modules;         /* Explicit list of misc modules to load */ 
+    char *misc_modules;         /* Explicit list of misc modules to load */
     bool resolve_hosts;         /* Set optionally by rcmd modules */
 
-    bool kill_on_fail;          
+    bool kill_on_fail;
 
     /* DSH-specific options */
     bool separate_stderr;       /* -s */
@@ -103,7 +103,7 @@ bool opt_verify(opt_t *);
 void opt_list(opt_t *);
 void opt_free(opt_t *);
 
-/* 
+/*
  *  Return the current pdsh "personality"
  */
 pers_t pdsh_personality(void);
@@ -120,8 +120,8 @@ const char ** pdsh_remote_argv (void);
 int pdsh_remote_argc (void);
 
 /*
- * Structure for pdsh modules to export new options. 
- * 
+ * Structure for pdsh modules to export new options.
+ *
  * Module should define a table of options as:
  *
  *     struct pdsh_module_option pdsh_module_opts[] = { ... };
@@ -130,7 +130,7 @@ int pdsh_remote_argc (void);
  *   (see mod.c) will call opt_register for each of the defined
  *   options. If any option fails to register, the module will
  *   be unloaded and a warning message printed.
- */ 
+ */
 
 typedef int (*optFunc)(opt_t *opt, int optopt, char *optarg);
 
@@ -139,7 +139,7 @@ struct pdsh_module_option {
     char   *arginfo;      /* one word descr of arg if option takes one      */
     char   *descr;        /* short description of option                    */
     int     personality;  /* Personality for which this option is suitable. *
-                           * May be set to DSH, PCP, or DSH |PCP            */  
+                           * May be set to DSH, PCP, or DSH |PCP            */
 
     optFunc f;            /* callback function for option processing        */
 };

--- a/src/pdsh/pcp_client.c
+++ b/src/pdsh/pcp_client.c
@@ -5,20 +5,20 @@
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Jim Garlick <garlick@llnl.gov>.
  *  UCRL-CODE-2003-005.
- *  
+ *
  *  This file is part of Pdsh, a parallel remote shell program.
  *  For details, see <http://www.llnl.gov/linux/pdsh/>.
- *  
+ *
  *  Pdsh is free software; you can redistribute it and/or modify it under
  *  the terms of the GNU General Public License as published by the Free
  *  Software Foundation; either version 2 of the License, or (at your option)
  *  any later version.
- *  
+ *
  *  Pdsh is distributed in the hope that it will be useful, but WITHOUT ANY
  *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
  *  details.
- *  
+ *
  *  You should have received a copy of the GNU General Public License along
  *  with Pdsh; if not, write to the Free Software Foundation, Inc.,
  *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
@@ -130,7 +130,7 @@ static void _rexpand_dir(List list, char *name)
      * efficiency, we must specify a special flag so we know when
      * to tell the server to "move up" the directory tree.
      */
-    
+
     /* XXX: This memleaks */
     pf = Malloc(sizeof(struct pcp_filename));
     pf->filename = Strdup(EXIT_SUBDIR_FILENAME);
@@ -153,7 +153,7 @@ List pcp_expand_dirs(List infiles)
             errx("%p: access: %s: %m\n", name);
         if (stat(name, &sb) < 0)
             errx("%p: stat: %s: %m\n", name);
-        
+
         /* XXX: This memleaks */
         pf = Malloc(sizeof(struct pcp_filename));
         pf->filename = name;
@@ -165,14 +165,14 @@ List pcp_expand_dirs(List infiles)
         if (S_ISDIR(sb.st_mode))
             _rexpand_dir(new, name);
     }
-    
+
     return new;
 }
 
 /*
  * Wrapper for the write system call that handles short writes.
  * Not sure if write ever returns short in practice but we have to be sure.
- *	fd (IN)		file descriptor to write to 
+ *	fd (IN)		file descriptor to write to
  *	buf (IN)	data to write
  *	size (IN)	size of buf
  *	RETURN		-1 on failure, size on success
@@ -197,7 +197,7 @@ static int _pcp_write(int fd, char *buf, int size)
 
 /*
  * Write the contents of the named file to the specified file descriptor.
- *	outfd (IN)	file descriptor to write to 
+ *	outfd (IN)	file descriptor to write to
  *	filename (IN)	name of file
  *	host (IN)	name of remote host for error messages
  *	RETURN		-1 on failure, 0 on success.
@@ -245,7 +245,7 @@ static int pcp_sendstr(int outfd, char *str, char *host)
     assert(strlen(str) > 0);
     assert(str[strlen(str) - 1] == '\n');
 
-    if ((n = _pcp_write(outfd, str, strlen(str))) < 0) 
+    if ((n = _pcp_write(outfd, str, strlen(str))) < 0)
         return -1;
 
     assert(n == strlen(str));
@@ -265,7 +265,7 @@ static int pcp_response(int infd, char *host)
     int n;
     char errstr[BUFSIZ];
 
-    if ((n = read(infd, &resp, sizeof(resp))) != sizeof(resp)) 
+    if ((n = read(infd, &resp, sizeof(resp))) != sizeof(resp))
         return (-1);
 
     switch (resp) {
@@ -302,8 +302,8 @@ int pcp_sendfile(struct pcp_client *pcp, char *file, char *output_file)
     }
 
     if (pcp->preserve) {
-        /* 
-         * 1: SEND stat time: "T%ld %ld %ld %ld\n" 
+        /*
+         * 1: SEND stat time: "T%ld %ld %ld %ld\n"
          *    (st_mtime, st_mtime_usec, st_atime, st_atime_usec)
          */
         snprintf(tmpstr, sizeof(tmpstr), "T%ld %ld %ld %ld\n",
@@ -317,7 +317,7 @@ int pcp_sendfile(struct pcp_client *pcp, char *file, char *output_file)
     }
 
     if (S_ISDIR(sb.st_mode)) {
-        /* 
+        /*
          * 3a: SEND directory mode: "D%04o %d %s\n"
          *     (st_mode & RCP_MODEMASK, 0, name)
          */
@@ -326,7 +326,7 @@ int pcp_sendfile(struct pcp_client *pcp, char *file, char *output_file)
         if (pcp_sendstr(pcp->outfd, tmpstr, pcp->host) < 0)
             goto fail;
     } else {
-        /* 
+        /*
          * 3b: SEND file mode: "C%04o %lld %s\n" or "C%04o %ld %s\n"
          *    (st_mode & MODE_MASK, st_size, basename(filename))
          *    Use second template if sizeof(st_size) > sizeof(long).

--- a/src/pdsh/pcp_client.h
+++ b/src/pdsh/pcp_client.h
@@ -5,20 +5,20 @@
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Jim Garlick <garlick@llnl.gov>.
  *  UCRL-CODE-2003-005.
- *  
+ *
  *  This file is part of Pdsh, a parallel remote shell program.
  *  For details, see <http://www.llnl.gov/linux/pdsh/>.
- *  
+ *
  *  Pdsh is free software; you can redistribute it and/or modify it under
  *  the terms of the GNU General Public License as published by the Free
  *  Software Foundation; either version 2 of the License, or (at your option)
  *  any later version.
- *  
+ *
  *  Pdsh is distributed in the hope that it will be useful, but WITHOUT ANY
  *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
  *  details.
- *  
+ *
  *  You should have received a copy of the GNU General Public License along
  *  with Pdsh; if not, write to the Free Software Foundation, Inc.,
  *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
@@ -29,7 +29,7 @@
 
 #if HAVE_CONFIG_H
 #  include <config.h>
-#endif 
+#endif
 
 #include "src/pdsh/opt.h"
 

--- a/src/pdsh/pcp_server.c
+++ b/src/pdsh/pcp_server.c
@@ -5,20 +5,20 @@
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Jim Garlick <garlick@llnl.gov>.
  *  UCRL-CODE-2003-005.
- *  
+ *
  *  This file is part of Pdsh, a parallel remote shell program.
  *  For details, see <http://www.llnl.gov/linux/pdsh/>.
- *  
+ *
  *  Pdsh is free software; you can redistribute it and/or modify it under
  *  the terms of the GNU General Public License as published by the Free
  *  Software Foundation; either version 2 of the License, or (at your option)
  *  any later version.
- *  
+ *
  *  Pdsh is distributed in the hope that it will be useful, but WITHOUT ANY
  *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
  *  details.
- *  
+ *
  *  You should have received a copy of the GNU General Public License along
  *  with Pdsh; if not, write to the Free Software Foundation, Inc.,
  *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
@@ -108,7 +108,7 @@ char rcsid[] = "$Id$";
  * - removal of conditions that are impossible to hit in pdcp
  * - update error messages to use pdcp error functions
  * - minor changes to enhance readability and fit style to rest
- *   of pdsh/pdcp code. 
+ *   of pdsh/pdcp code.
  * - pass infd/outfd through structure rather than global
  * - don't exit on error, just return
  */
@@ -334,8 +334,8 @@ _sink(struct pcp_server *svr, char *targ, BUF *bufp) {
             if (need > cursize) {
                 if (namebuf)
                     free(namebuf);
-              
-                if (!(namebuf = malloc(need))) { 
+
+                if (!(namebuf = malloc(need))) {
                     _error(svr, "out of memory\n");
                     cursize = 0;
 
@@ -378,7 +378,7 @@ _sink(struct pcp_server *svr, char *targ, BUF *bufp) {
         }
 
         if ((ofd = open(np, O_WRONLY|O_CREAT, mode)) < 0) {
-bad:	     
+bad:	
             _error(svr, "%s: %m\n", np);
             continue;
         }
@@ -455,7 +455,7 @@ end_server:
     return;
 }
 
-int pcp_server(struct pcp_server *svr) 
+int pcp_server(struct pcp_server *svr)
 {
 	BUF buffer;
 	memset (&buffer, 0, sizeof (buffer));

--- a/src/pdsh/pcp_server.h
+++ b/src/pdsh/pcp_server.h
@@ -5,20 +5,20 @@
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Jim Garlick <garlick@llnl.gov>.
  *  UCRL-CODE-2003-005.
- *  
+ *
  *  This file is part of Pdsh, a parallel remote shell program.
  *  For details, see <http://www.llnl.gov/linux/pdsh/>.
- *  
+ *
  *  Pdsh is free software; you can redistribute it and/or modify it under
  *  the terms of the GNU General Public License as published by the Free
  *  Software Foundation; either version 2 of the License, or (at your option)
  *  any later version.
- *  
+ *
  *  Pdsh is distributed in the hope that it will be useful, but WITHOUT ANY
  *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
  *  details.
- *  
+ *
  *  You should have received a copy of the GNU General Public License along
  *  with Pdsh; if not, write to the Free Software Foundation, Inc.,
  *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
@@ -29,7 +29,7 @@
 
 #if HAVE_CONFIG_H
 #  include <config.h>
-#endif 
+#endif
 
 #include "src/pdsh/opt.h"
 

--- a/src/pdsh/privsep.c
+++ b/src/pdsh/privsep.c
@@ -5,20 +5,20 @@
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Jim Garlick <garlick@llnl.gov>.
  *  UCRL-CODE-2003-005.
- *  
+ *
  *  This file is part of Pdsh, a parallel remote shell program.
  *  For details, see <http://www.llnl.gov/linux/pdsh/>.
- *  
+ *
  *  Pdsh is free software; you can redistribute it and/or modify it under
  *  the terms of the GNU General Public License as published by the Free
  *  Software Foundation; either version 2 of the License, or (at your option)
  *  any later version.
- *  
+ *
  *  Pdsh is distributed in the hope that it will be useful, but WITHOUT ANY
  *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
  *  details.
- *  
+ *
  *  You should have received a copy of the GNU General Public License along
  *  with Pdsh; if not, write to the Free Software Foundation, Inc.,
  *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
@@ -140,7 +140,7 @@ static int send_rresvport (int pipefd, int fd, int lport)
 		msg.msg_accrights = (caddr_t) &fd;
 		msg.msg_accrightslen = sizeof (int);
 	}
-#else 
+#else
 	if (fd < 0) {
 		msg.msg_control = NULL;
 		msg.msg_controllen = 0;
@@ -256,7 +256,7 @@ static int create_privileged_child (void)
 	}
 
 	if (cpid == 0) {
-		/* 
+		/*
 		 * Child: become privilege port server.
 		 */
 		privsep_server ();
@@ -297,7 +297,7 @@ int privsep_fini (void)
 		return (-1);
 	}
 
-	if (status) 
+	if (status)
 		err ("%p: privileged chiled exited with status %d\n", status);
 
 	return (0);

--- a/src/pdsh/privsep.h
+++ b/src/pdsh/privsep.h
@@ -5,20 +5,20 @@
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Jim Garlick <garlick@llnl.gov>.
  *  UCRL-CODE-2003-005.
- *  
+ *
  *  This file is part of Pdsh, a parallel remote shell program.
  *  For details, see <http://www.llnl.gov/linux/pdsh/>.
- *  
+ *
  *  Pdsh is free software; you can redistribute it and/or modify it under
  *  the terms of the GNU General Public License as published by the Free
  *  Software Foundation; either version 2 of the License, or (at your option)
  *  any later version.
- *  
+ *
  *  Pdsh is distributed in the hope that it will be useful, but WITHOUT ANY
  *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
  *  details.
- *  
+ *
  *  You should have received a copy of the GNU General Public License along
  *  with Pdsh; if not, write to the Free Software Foundation, Inc.,
  *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.

--- a/src/pdsh/rcmd.c
+++ b/src/pdsh/rcmd.c
@@ -5,20 +5,20 @@
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Mark Grondona <mgrondona@llnl.gov>.
  *  UCRL-CODE-2003-005.
- *  
+ *
  *  This file is part of Pdsh, a parallel remote shell program.
  *  For details, see <http://www.llnl.gov/linux/pdsh/>.
- *  
+ *
  *  Pdsh is free software; you can redistribute it and/or modify it under
  *  the terms of the GNU General Public License as published by the Free
  *  Software Foundation; either version 2 of the License, or (at your option)
  *  any later version.
- *  
+ *
  *  Pdsh is distributed in the hope that it will be useful, but WITHOUT ANY
  *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
  *  details.
- *  
+ *
  *  You should have received a copy of the GNU General Public License along
  *  with Pdsh; if not, write to the Free Software Foundation, Inc.,
  *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
@@ -44,7 +44,7 @@
  *  Ordered preference for determining default rcmd method.
  *   Warning: If none of these modules are loaded, there will be no default.
  */
-static char * rcmd_rank[] = 
+static char * rcmd_rank[] =
 #if defined(RCMD_RANK_LIST)
     { RCMD_RANK_LIST, NULL };
 #else
@@ -73,7 +73,7 @@ static List rcmd_module_list = NULL;
 static struct rcmd_module *default_rcmd_module = NULL;
 static struct rcmd_module *current_rcmd_module = NULL;
 
-static struct node_rcmd_info * 
+static struct node_rcmd_info *
 node_rcmd_info_create (char *hostname, char *user, struct rcmd_module *module)
 {
     struct node_rcmd_info *n = Malloc (sizeof (*n));
@@ -169,8 +169,8 @@ static struct rcmd_module * rcmd_module_register (char *name)
     if (rcmd_module_list == NULL)
         rcmd_module_list = list_create ((ListDelF) rcmd_module_destroy);
     else
-        rmod = list_find_first (rcmd_module_list, 
-                                (ListFindF) find_rcmd_module, 
+        rmod = list_find_first (rcmd_module_list,
+                                (ListFindF) find_rcmd_module,
                                 name);
     if (rmod != NULL)
         return (rmod);
@@ -200,14 +200,14 @@ static int hostlist_register_rcmd (const char *hosts, struct rcmd_module *rmod,
 
     if (hl == NULL)
         return (-1);
-    
+
     if (host_info_list == NULL)
         host_info_list = list_create ((ListDelF) node_rcmd_info_destroy);
 
     while ((host = hostlist_pop (hl))) {
         struct node_rcmd_info *n = NULL;
 
-        /* 
+        /*
          *  Do not override previously installed host info. First registered
          *   rcmd type for a host wins. This allows command line to override
          *   everything else.
@@ -221,7 +221,7 @@ static int hostlist_register_rcmd (const char *hosts, struct rcmd_module *rmod,
         list_append (host_info_list, n);
 
         free (host);
-    
+
     }
 
     hostlist_destroy (hl);
@@ -244,7 +244,7 @@ char * rcmd_get_default_module (void)
     if (default_rcmd_module != NULL)
         return (default_rcmd_module->name);
 
-    while ((name = rcmd_rank[i++]) && !mod) 
+    while ((name = rcmd_rank[i++]) && !mod)
         mod = mod_get_module ("rcmd", name);
 
     return mod ? mod_get_name (mod) : NULL;
@@ -311,9 +311,9 @@ struct rcmd_info * rcmd_create (char *host)
 
     if ((n = host_rcmd_info (host))) {
         rmod = n->rmod;
-    } 
+    }
 
-    /* 
+    /*
      * If no rcmd module use default
      */
     if (rmod == NULL) {
@@ -322,7 +322,7 @@ struct rcmd_info * rcmd_create (char *host)
             return (NULL);
         }
     }
-    
+
     if ((rcmd = rcmd_info_create (rmod)) == NULL) {
         err ("%p: Unable to allocate rcmd info for \"%s\"\n", host);
         return (NULL);
@@ -335,8 +335,8 @@ struct rcmd_info * rcmd_create (char *host)
 }
 
 
-int rcmd_connect (struct rcmd_info *rcmd, char *ahost, char *addr, 
-                  char *locuser, char *remuser, char *cmd, int nodeid, 
+int rcmd_connect (struct rcmd_info *rcmd, char *ahost, char *addr,
+                  char *locuser, char *remuser, char *cmd, int nodeid,
                   bool error_fd)
 {
     /*
@@ -345,7 +345,7 @@ int rcmd_connect (struct rcmd_info *rcmd, char *ahost, char *addr,
     if (rcmd->ruser)
         remuser = rcmd->ruser;
 
-    rcmd->fd = (*rcmd->rmod->rcmd) (ahost, addr, locuser, remuser, cmd, nodeid, 
+    rcmd->fd = (*rcmd->rmod->rcmd) (ahost, addr, locuser, remuser, cmd, nodeid,
                                     error_fd ? &rcmd->efd : NULL, &rcmd->arg);
     return (rcmd->fd);
 }
@@ -416,7 +416,7 @@ int rcmd_opt_set (int id, void * value)
     }
 
     switch (id) {
-        case RCMD_OPT_RESOLVE_HOSTS: 
+        case RCMD_OPT_RESOLVE_HOSTS:
             current_rcmd_module->options.resolve_hosts = (long int) value;
             break;
         default:

--- a/src/pdsh/rcmd.h
+++ b/src/pdsh/rcmd.h
@@ -5,20 +5,20 @@
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Mark Grondona <mgrondona@llnl.gov>.
  *  UCRL-CODE-2003-005.
- *  
+ *
  *  This file is part of Pdsh, a parallel remote shell program.
  *  For details, see <http://www.llnl.gov/linux/pdsh/>.
- *  
+ *
  *  Pdsh is free software; you can redistribute it and/or modify it under
  *  the terms of the GNU General Public License as published by the Free
  *  Software Foundation; either version 2 of the License, or (at your option)
  *  any later version.
- *  
+ *
  *  Pdsh is distributed in the hope that it will be useful, but WITHOUT ANY
  *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
  *  details.
- *  
+ *
  *  You should have received a copy of the GNU General Public License along
  *  with Pdsh; if not, write to the Free Software Foundation, Inc.,
  *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
@@ -46,7 +46,7 @@ struct rcmd_info {
 
 
 /*
- *  Register default rcmd parameters for hosts in hostlist string "hosts." 
+ *  Register default rcmd parameters for hosts in hostlist string "hosts."
  *    rcmd_type - if non-NULL set default rcmd connect module for "hosts."
  *    user      - if non-NULL set default remote username for "hosts."
  *
@@ -75,10 +75,10 @@ char * rcmd_get_default_module (void);
 struct rcmd_info * rcmd_create (char *host);
 
 /*
- *  Connect using rcmd_info rcmd 
+ *  Connect using rcmd_info rcmd
  */
-int rcmd_connect (struct rcmd_info *rcmd, char *host, char *addr, 
-                  char *locuser, char *remuser, char *cmd, int nodeid, 
+int rcmd_connect (struct rcmd_info *rcmd, char *host, char *addr,
+                  char *locuser, char *remuser, char *cmd, int nodeid,
 		  bool err);
 
 /*
@@ -99,11 +99,11 @@ int rcmd_init (opt_t *opt);
 int rcmd_exit (void);
 
 /*
- *  Called by rcmd module during "init" function to set various 
+ *  Called by rcmd module during "init" function to set various
  *   rcmd-specific options. (see rcmd_options structure above)
- *  
+ *
  *  Returns -1 with errno set to ESRCH if called from anywhere but
- *   module's rcmd_init function. 
+ *   module's rcmd_init function.
  */
 int rcmd_opt_set (int id, void * value);
 

--- a/src/pdsh/testcase.c
+++ b/src/pdsh/testcase.c
@@ -5,20 +5,20 @@
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Jim Garlick <garlick@llnl.gov>.
  *  UCRL-CODE-2003-005.
- *  
+ *
  *  This file is part of Pdsh, a parallel remote shell program.
  *  For details, see <http://www.llnl.gov/linux/pdsh/>.
- *  
+ *
  *  Pdsh is free software; you can redistribute it and/or modify it under
  *  the terms of the GNU General Public License as published by the Free
  *  Software Foundation; either version 2 of the License, or (at your option)
  *  any later version.
- *  
+ *
  *  Pdsh is distributed in the hope that it will be useful, but WITHOUT ANY
  *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
  *  details.
- *  
+ *
  *  You should have received a copy of the GNU General Public License along
  *  with Pdsh; if not, write to the Free Software Foundation, Inc.,
  *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.

--- a/src/pdsh/wcoll.c
+++ b/src/pdsh/wcoll.c
@@ -187,10 +187,10 @@ static char * wcoll_ctx_resolve_path (struct wcoll_ctx *ctx,
         const char *file, char *buf, int len)
 {
     if (file[0] == '/')
-        strncpy (buf, file, len);
+        strncpy (buf, file, len - 1);
     else if ( file[0] == '.'
             && (file[1] == '/' || (file[1] == '.' && file[2] == '/')))
-       strncpy (buf, file, len);
+       strncpy (buf, file, len - 1);
     else {
         if (wcoll_ctx_path_lookup (ctx, file, buf, len) < 0)
             return NULL;

--- a/src/pdsh/wcoll.c
+++ b/src/pdsh/wcoll.c
@@ -5,20 +5,20 @@
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Jim Garlick <garlick@llnl.gov>.
  *  UCRL-CODE-2003-005.
- *  
+ *
  *  This file is part of Pdsh, a parallel remote shell program.
  *  For details, see <http://www.llnl.gov/linux/pdsh/>.
- *  
+ *
  *  Pdsh is free software; you can redistribute it and/or modify it under
  *  the terms of the GNU General Public License as published by the Free
  *  Software Foundation; either version 2 of the License, or (at your option)
  *  any later version.
- *  
+ *
  *  Pdsh is distributed in the hope that it will be useful, but WITHOUT ANY
  *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
  *  details.
- *  
+ *
  *  You should have received a copy of the GNU General Public License along
  *  with Pdsh; if not, write to the Free Software Foundation, Inc.,
  *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
@@ -317,9 +317,9 @@ static char * get_file_path (const char *file, char *dir, int len)
 
 /*
  * Read wcoll from specified file or from the specified FILE pointer.
- * (one of the arguments must be NULL).  
+ * (one of the arguments must be NULL).
  *      file (IN)       name of wcoll file (or NULL)
- *      f (IN)          FILE pointer to wcoll file (or NULL)    
+ *      f (IN)          FILE pointer to wcoll file (or NULL)
  *      RETURN          new list containing hostnames
  */
 hostlist_t read_wcoll(char *file, FILE * f)

--- a/src/pdsh/wcoll.h
+++ b/src/pdsh/wcoll.h
@@ -5,20 +5,20 @@
  *  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
  *  Written by Jim Garlick <garlick@llnl.gov>.
  *  UCRL-CODE-2003-005.
- *  
+ *
  *  This file is part of Pdsh, a parallel remote shell program.
  *  For details, see <http://www.llnl.gov/linux/pdsh/>.
- *  
+ *
  *  Pdsh is free software; you can redistribute it and/or modify it under
  *  the terms of the GNU General Public License as published by the Free
  *  Software Foundation; either version 2 of the License, or (at your option)
  *  any later version.
- *  
+ *
  *  Pdsh is distributed in the hope that it will be useful, but WITHOUT ANY
  *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  *  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
  *  details.
- *  
+ *
  *  You should have received a copy of the GNU General Public License along
  *  with Pdsh; if not, write to the Free Software Foundation, Inc.,
  *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.


### PR DESCRIPTION
This PR adapts @erikja's proposal in #142, but only emits the messages with the `-d` option.

The manpages are also updated with an expanded description of the `-d` option.

Some cleanup is tacked on as well - suppressing some warnings and also removing all the annoying trailing whitespace in the codebase.