### PR TITLE
common/hostlist: fix out of bounds array access

### DIFF
--- a/src/common/hostlist.c
+++ b/src/common/hostlist.c
@@ -2278,6 +2278,11 @@ static void _iterator_advance(hostlist_iterator_t i)
         return;
     if (++(i->depth) > (i->hr->hi - i->hr->lo)) {
         i->depth = 0;
+        if (i->idx >= (i->hl->size - 1)) {
+            ++i->idx;
+            i->hr = NULL;
+            return;
+        }
         i->hr = i->hl->hr[++i->idx];
     }
 }


### PR DESCRIPTION
Problem: Internally within the hostlist data structure, an array of hostranges is kept.  An out of bounds array access can occur if the number of hostranges is equal to the length of the array.

Add check to ensure out of bound array access is not allowed when iterating hosts.