### PR TITLE
Fix build on C23 compiler (gcc >= 15)

### DIFF
--- a/src/common/macros.h
+++ b/src/common/macros.h
@@ -58,9 +58,11 @@
 
 #ifndef _BOOL_DEFINED
 #  define _BOOL_DEFINED
+# if __STDC_VERSION__ < 202311L
 #  if !defined (true) && !defined (false)
 typedef enum { false, true } bool;
 #  endif
+# endif
 #endif
 
 #endif                          /* !_MACROS_INCLUDED */


### PR DESCRIPTION
'true' and 'false' are proper keywords in C23.
This fixes issue #165.