### PR TITLE
Fix some compiler warnings when compiling pdsh

### DIFF
--- a/src/modules/mcmd.c
+++ b/src/modules/mcmd.c
@@ -207,8 +207,12 @@ mcmd_init(opt_t * opt)
     /*
      * Drop privileges if running setuid root
      */
-    if ((geteuid() == 0) && (getuid() != 0))
-        setuid (getuid ());
+    if ((geteuid() == 0) && (getuid() != 0)) {
+        if ((setuid (getuid ()) < 0)) {
+            err("%p: mcmd: setuid () failed\n");
+            return -1;
+	}
+    }
 
     /*
      * Generate a random number to send in our package to the
@@ -277,8 +281,8 @@ encode_localhost_string (const char *host, char *str, int maxlen)
     if (gethostname (hostname, MAXHOSTNAMELEN) < 0)
         errx ("mcmd: gethostname: %m\n");
 
-    strncpy (str, MRSH_LOCALHOST_KEY, MRSH_LOCALHOST_KEYLEN);
-    strncat (str, hostname, maxlen - MRSH_LOCALHOST_KEYLEN - 1);
+    strncpy (str, MRSH_LOCALHOST_KEY, MRSH_LOCALHOST_KEYLEN + 1);
+    strncat (str, hostname, maxlen - MRSH_LOCALHOST_KEYLEN);
 
     return (strlen (str));
 }

--- a/src/pdsh/cbuf.c
+++ b/src/pdsh/cbuf.c
@@ -817,7 +817,8 @@ cbuf_write_line (cbuf_t dst, char *srcbuf, int *ndropped)
 {
     int len;
     int nfree, ncopy, n;
-    int ndrop = 0, d;
+    int ndrop = 0;
+    int d = 0;
     char *psrc = srcbuf;
     char *newline = "\n";
 


### PR DESCRIPTION
Compiling pdsh I get following warnings:
```
cbuf.c: In function ‘cbuf_write_line’:
cbuf.c:878:19: warning: ‘d’ may be used uninitialized [-Wmaybe-uninitialized]
  878 |             ndrop += d;
      |             ~~~~~~^~~~
cbuf.c:820:20: note: ‘d’ was declared here
  820 |     int ndrop = 0, d;
      |                    ^
mcmd.c: In function 'mcmd_init':
mcmd.c:211:9: warning: ignoring return value of 'setuid' declared with attribute 'warn_unused_result' [-Wunused-result]
  211 |         setuid (getuid ());
      |         ^~~~~~~~~~~~~~~~~~
mcmd.c: In function 'mcmd':
mcmd.c:280:5: warning: 'strncpy' output truncated before terminating nul copying 5 bytes from a string of the same length [-Wstringop-truncation]
  280 |     strncpy (str, MRSH_LOCALHOST_KEY, MRSH_LOCALHOST_KEYLEN);
      |     ^
mcmd.c:281:5: warning: '__strncat_chk' output may be truncated copying 64 bytes from a string of length 64 [-Wstringop-truncation]
  281 |     strncat (str, hostname, maxlen - MRSH_LOCALHOST_KEYLEN - 1);
      |     ^
```

This PR tries to fix those warnings.